### PR TITLE
fixed README so that example runs (was missing `Lambda` import)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The following is a sample `tm.py` file that describes a simple application where
 
 # !/usr/bin/env python3
 
-from pytm.pytm import TM, Server, Datastore, Dataflow, Boundary, Actor
+from pytm.pytm import TM, Server, Datastore, Dataflow, Boundary, Actor, Lambda
 
 tm = TM("my test tm")
 tm.description = "another test tm"


### PR DESCRIPTION
The _README.md_ file included an example PyTM script that was missing an import; this PR simply adds that import to the example script so that users can easily run the example and see the output from PyTM