### PR TITLE
Remove redundant space

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The following is a sample `tm.py` file that describes a simple application where
 
 ```python
 
-# !/usr/bin/env python3
+#!/usr/bin/env python3
 
 from pytm.pytm import TM, Server, Datastore, Dataflow, Boundary, Actor, Lambda
 


### PR DESCRIPTION
Otherwise I get the following on mac for`./tm.py --dfd`:
```
from: can't read /var/mail/pytm.pytm
./tm.py: line 5: syntax error near unexpected token `('
./tm.py: line 5: `tm = TM("my test tm")'
```