### PR TITLE
render elements with duplicate names in the DFD

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,8 @@ Sometimes you will find the root cause yourself in the process.
 
 Try to give your issue a title that is succinct and specific. The devs will rename issues as needed to keep track of them.
 
+To execute the test suite, from the root of the repo run `python3 -m unittest -v`.
+
 ## PyTM-users
 
 Before you post to the [PyTM-users list](https://groups.google.com/forum/#!forum/pytm-users), make sure you look for existing solutions.

--- a/tests/test_private_func.py
+++ b/tests/test_private_func.py
@@ -1,0 +1,14 @@
+import unittest
+
+from pytm.pytm import _uniq_name, Boundary
+
+
+class TestUniqueNames(unittest.TestCase):
+    def test_duplicate_boundary_names_have_different_unique_names(self):
+        object_1 = Boundary("foo")
+        object_2 = Boundary("foo")
+
+        object_1_uniq_name = _uniq_name(object_1.name, object_1.uuid)
+        object_2_uniq_name = _uniq_name(object_2.name, object_2.uuid)
+
+        self.assertNotEqual(object_1_uniq_name, object_2_uniq_name)

--- a/tests/test_pytmfunc.py
+++ b/tests/test_pytmfunc.py
@@ -6,11 +6,12 @@ import json
 import os
 from os.path import dirname
 
-with open(os.path.abspath(os.path.join(dirname(__file__), '..')) + "/threatlib/threats.json", "r") as threat_file:
+with open(os.path.abspath(os.path.join(dirname(__file__), "../pytm/threatlib/threats.json", )), "r") as threat_file:
     threats_json = json.load(threat_file)
-    
+
+
 class Testpytm(unittest.TestCase):
-    
+
 #Test for all the threats in threats.py - test Threat.apply() function
     def test_INP01(self):
         lambda1 = Lambda('mylambda')


### PR DESCRIPTION
Fixes #45

See reproducer [here](https://github.com/izar/pytm/issues/45#issuecomment-551381567), which now renders objects with duplicate names:

![dfd](https://user-images.githubusercontent.com/7832803/68450147-f63c2080-01b7-11ea-8968-180ad0bffcd5.png)
