### PR TITLE
bugfix UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in …

### DIFF
--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -191,7 +191,7 @@ class TM():
         self.name = name
         self._sf = SuperFormatter()
         # load Threats
-        with open(dirname(__file__) + "/threatlib/threats.json", "r") as threat_file:
+        with open(dirname(__file__) + "/threatlib/threats.json", "r", encoding="utf8") as threat_file:
             threats_json = json.load(threat_file)
 
         for i in threats_json:


### PR DESCRIPTION
…position 54258: character maps to <undefined>

When I try to execute the example, I get the following error message:
Traceback (most recent call last):
  File "tm.py", line 5, in <module>
    tm = TM("my test tm")
  File "C:\Users\thorbne\PycharmProjects\pytm\pytm\pytm.py", line 195, in __init__
    threats_json = json.load(threat_file)
  File "C:\Users\thorbne\AppData\Local\Programs\Python\Python38\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
  File "C:\Users\thorbne\AppData\Local\Programs\Python\Python38\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 54258: character maps to <undefined>

It's because python is using a wrong enconding. I added utf-8 as encoding to be used and now the example is working fine.