### PR TITLE
bugfix: 'TypeError: _uniq_name() missing 1 required positional argume…

### DIFF
--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -229,13 +229,13 @@ class TM():
             if type(e) is Actor:
                 print("actor {0} as \"{1}\"".format(_uniq_name(e.name, e.uuid), e.name))
             elif type(e) is Datastore:
-                print("database {0} as \"{1}\"".format(_uniq_name(e.name), e.name))
+                print("database {0} as \"{1}\"".format(_uniq_name(e.name, e.uuid), e.name))
             elif type(e) is not Dataflow and type(e) is not Boundary:
-                print("entity {0} as \"{1}\"".format(_uniq_name(e.name), e.name))
+                print("entity {0} as \"{1}\"".format(_uniq_name(e.name, e.uuid), e.name))
 
         ordered = sorted(TM._BagOfFlows, key=lambda flow: flow.order)
         for e in ordered:
-            print("{0} -> {1}: {2}".format(_uniq_name(e.source.name), _uniq_name(e.sink.name), e.name))
+            print("{0} -> {1}: {2}".format(_uniq_name(e.source.name, e.source.uuid), _uniq_name(e.sink.name, e.sink.uuid), e.name))
             if e.note != "":
                 print("note left\n{}\nend note".format(e.note))
         print("@enduml")


### PR DESCRIPTION
./tm.py --seq
@startuml
actor cbdcbcbdaaddaadbdfadadfaaae as "User"
Traceback (most recent call last):
File "./tm.py", line 64, in
tm.process()
File "/opt/pytm/pytm/pytm.py", line 255, in process
self.seq()
File "/opt/pytm/pytm/pytm.py", line 234, in seq
print("entity {0} as "{1}"".format(_uniq_name(e.name), e.name))
TypeError: _uniq_name() missing 1 required positional argument: 'obj_uuid'

uuid is missing. 
This is also why I was not able to create sequence diagrams on Windows environment. Now it is again working on both Linux & Windows.