### PR TITLE
allow setting properties on init

### DIFF
--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -187,7 +187,9 @@ class TM():
     _sf = None
     description = varString("")
 
-    def __init__(self, name):
+    def __init__(self, name, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
         self.name = name
         self._sf = SuperFormatter()
         # load Threats
@@ -288,7 +290,9 @@ class Element():
     OS = varString("")
     isAdmin = varBool(False)
 
-    def __init__(self, name):
+    def __init__(self, name, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
         self.name = name
         self.uuid = uuid.uuid4()
         self._is_drawn = False
@@ -323,8 +327,8 @@ class Lambda(Element):
     implementsAPI = varBool(False)
     authorizesSource = varBool(False)
 
-    def __init__(self, name):
-        super().__init__(name)
+    def __init__(self, name, **kwargs):
+        super().__init__(name, **kwargs)
 
     def dfd(self):
         self._is_drawn = True
@@ -369,8 +373,8 @@ class Server(Element):
     checksInputBounds = varBool(False)
     implementsStrictHTTPValidation = varBool(False)
 
-    def __init__(self, name):
-        super().__init__(name)
+    def __init__(self, name, **kwargs):
+        super().__init__(name, **kwargs)
 
     def dfd(self):
         self._is_drawn = True
@@ -387,8 +391,8 @@ class ExternalEntity(Element):
     definesConnectionTimeout = varBool(False)
     hasPhysicalAccess = varBool(False)
 
-    def __init__(self, name):
-        super().__init__(name)
+    def __init__(self, name, **kwargs):
+        super().__init__(name, **kwargs)
 
 
 class Datastore(Element):
@@ -415,8 +419,8 @@ class Datastore(Element):
     validatesInput = varBool(False)
     implementsPOLP = varBool(False)
 
-    def __init__(self, name):
-        super().__init__(name)
+    def __init__(self, name, **kwargs):
+        super().__init__(name, **kwargs)
 
     def dfd(self):
         self._is_drawn = True
@@ -429,8 +433,8 @@ class Datastore(Element):
 class Actor(Element):
     isAdmin = varBool(False)
 
-    def __init__(self, name):
-        super().__init__(name)
+    def __init__(self, name, **kwargs):
+        super().__init__(name, **kwargs)
 
     def dfd(self):
         self._is_drawn = True
@@ -479,8 +483,8 @@ class Process(Element):
     encryptsSessionData = varBool(False)
     verifySessionIdentifiers = varBool(False)
 
-    def __init__(self, name):
-        super().__init__(name)
+    def __init__(self, name, **kwargs):
+        super().__init__(name, **kwargs)
 
     def dfd(self):
         self._is_drawn = True
@@ -491,8 +495,8 @@ class Process(Element):
 
 
 class SetOfProcesses(Process):
-    def __init__(self, name):
-        super().__init__(name)
+    def __init__(self, name, **kwargs):
+        super().__init__(name, **kwargs)
 
     def dfd(self):
         self._is_drawn = True
@@ -520,11 +524,11 @@ class Dataflow(Element):
     usesSessionTokens = varBool(False)
     usesLatestTLSversion = varBool(False)
 
-    def __init__(self, source, sink, name):
+    def __init__(self, source, sink, name, **kwargs):
         self.source = source
         self.sink = sink
         self.name = name
-        super().__init__(name)
+        super().__init__(name, **kwargs)
         TM._BagOfFlows.append(self)
 
     def __set__(self, instance, value):
@@ -549,8 +553,8 @@ class Dataflow(Element):
 
 
 class Boundary(Element):
-    def __init__(self, name):
-        super().__init__(name)
+    def __init__(self, name, **kwargs):
+        super().__init__(name, **kwargs)
         if name not in TM._BagOfBoundaries:
             TM._BagOfBoundaries.append(self)
 


### PR DESCRIPTION
For elements/flows that have very few properties:
```python
webserver = Server("web server", inBoundary=internal)
request = Dataflow(user, webserver, "some request", dstPort=443)
```

For elements/flows with some common props:
```python
props = {
    "dstPort": 443,
    "protocol": "HTTPS",
}
login = Dataflow(user, webserver, "first request", **props)
do_stuff = Dataflow(user, webserver, "second request", **props)
```