### PR TITLE
Allow loading a custom threats file

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Element
 
 ```
 
-For the security practitioner, you may add new threats to the `threatlib/threats.json` file:
+For the security practitioner, you may supply your own threats file by setting `TM.threatsFile`. It should contain entries like:
 
 ```json
 {

--- a/tests/test_private_func.py
+++ b/tests/test_private_func.py
@@ -2,7 +2,7 @@ import sys
 sys.path.append("..")
 import unittest
 
-from pytm.pytm import _uniq_name, Boundary
+from pytm.pytm import _uniq_name, Boundary, Actor, TM
 
 
 class TestUniqueNames(unittest.TestCase):
@@ -14,3 +14,27 @@ class TestUniqueNames(unittest.TestCase):
         object_2_uniq_name = _uniq_name(object_2.name, object_2.uuid)
 
         self.assertNotEqual(object_1_uniq_name, object_2_uniq_name)
+
+
+class TestAttributes(unittest.TestCase):
+    def test_write_once(self):
+        user = Actor("User")
+        with self.assertRaises(ValueError):
+            user.name = "Computer"
+
+    def test_kwargs(self):
+        user = Actor("User", isAdmin=True)
+        self.assertEqual(user.isAdmin, True)
+        user = Actor("User")
+        self.assertEqual(user.isAdmin, False)
+        user.isAdmin = True
+        self.assertEqual(user.isAdmin, True)
+
+    def test_load_threats(self):
+        tm = TM("TM")
+        self.assertNotEqual(len(TM._BagOfThreats), 0)
+        with self.assertRaises(FileNotFoundError):
+            tm.threatsFile = "threats.json"
+
+        with self.assertRaises(FileNotFoundError):
+            TM("TM", threatsFile="threats.json")

--- a/tests/test_pytmfunc.py
+++ b/tests/test_pytmfunc.py
@@ -8,10 +8,10 @@ from os.path import dirname
 
 with open(os.path.abspath(os.path.join(dirname(__file__), '..')) + "/pytm/threatlib/threats.json", "r") as threat_file:
     threats_json = json.load(threat_file)
-    
+
 class Testpytm(unittest.TestCase):
-    
-#Test for all the threats in threats.py - test Threat.apply() function
+    # Test for all the threats in threats.py - test Threat.apply() function
+
     def test_INP01(self):
         lambda1 = Lambda('mylambda')
         process1 = Process('myprocess')
@@ -407,7 +407,6 @@ class Testpytm(unittest.TestCase):
     def test_INP15(self):
         web = Server("Web Server")
         web.protocol = 'IMAP'
-        web.protocol = 'SMTP'
         web.sanitizesInput = False
         ThreatObj = Threat(next(item for item in threats_json if item["SID"] == "INP15"))
         self.assertTrue(ThreatObj.apply(web))
@@ -858,5 +857,6 @@ class Testpytm(unittest.TestCase):
         ThreatObj = Threat(next(item for item in threats_json if item["SID"] == "AC21"))
         self.assertTrue(ThreatObj.apply(process1))
 
+
 if __name__ == '__main__':
-    unittest.main()   
+    unittest.main()


### PR DESCRIPTION
Allow loading a custom threats file by setting a new `TM.threatsFile` attribute.

Added throwing an exception when an attribute is already set, instead of silently ignoring the new value, which could lead to surprising errors.

Added missing unit tests.