### PR TITLE
Avoid boundary icons on sequence diagram as an entity

### DIFF
--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -218,7 +218,7 @@ class TM():
                 print("actor {0} as \"{1}\"".format(_uniq_name(e.name, e.uuid), e.name))
             elif isinstance(e, Datastore):
                 print("database {0} as \"{1}\"".format(_uniq_name(e.name, e.uuid), e.name))
-            elif not isinstance(e, Dataflow) and isinstance(e, Boundary):
+            elif not isinstance(e, Dataflow) and not isinstance(e, Boundary):
                 print("entity {0} as \"{1}\"".format(_uniq_name(e.name, e.uuid), e.name))
 
         ordered = sorted(TM._BagOfFlows, key=lambda flow: flow.order)


### PR DESCRIPTION
Modified conditional in line 221 to avoid boundary icon drawn as an entity on sequence diagram.
Check [#70](https://github.com/izar/pytm/issues/70)