### PR TITLE
dataflow inherits source and/or sink attrs

### DIFF
--- a/tests/test_private_func.py
+++ b/tests/test_private_func.py
@@ -64,3 +64,64 @@ class TestAttributes(unittest.TestCase):
 
         self.assertIsNone(insert.response)
         self.assertIs(insert.isResponse, False)
+
+    def test_defaults(self):
+        tm = TM("TM")
+        user = Actor("User", data="HTTP")
+        server = Server(
+            "Server", port=443, protocol="HTTPS", isEncrypted=True, data="JSON"
+        )
+        db = Datastore(
+            "PostgreSQL",
+            isSQL=True,
+            port=5432,
+            protocol="PostgreSQL",
+            isEncrypted=False,
+            data="SQL resp",
+        )
+
+        req_get = Dataflow(user, server, "HTTP GET")
+        query = Dataflow(server, db, "Query", data="SQL")
+        result = Dataflow(db, server, "Results", isResponse=True)
+        resp_get = Dataflow(server, user, "HTTP Response", isResponse=True)
+
+        req_post = Dataflow(user, server, "HTTP POST", data="JSON")
+        resp_post = Dataflow(server, user, "HTTP Response", isResponse=True)
+
+        tm.check()
+
+        self.assertEqual(req_get.srcPort, -1)
+        self.assertEqual(req_get.dstPort, server.port)
+        self.assertEqual(req_get.isEncrypted, server.isEncrypted)
+        self.assertEqual(req_get.protocol, server.protocol)
+        self.assertEqual(req_get.data, user.data)
+
+        self.assertEqual(query.srcPort, -1)
+        self.assertEqual(query.dstPort, db.port)
+        self.assertEqual(query.isEncrypted, db.isEncrypted)
+        self.assertEqual(query.protocol, db.protocol)
+        self.assertNotEqual(query.data, server.data)
+
+        self.assertEqual(result.srcPort, db.port)
+        self.assertEqual(result.dstPort, -1)
+        self.assertEqual(result.isEncrypted, db.isEncrypted)
+        self.assertEqual(result.protocol, db.protocol)
+        self.assertEqual(result.data, db.data)
+
+        self.assertEqual(resp_get.srcPort, server.port)
+        self.assertEqual(resp_get.dstPort, -1)
+        self.assertEqual(resp_get.isEncrypted, server.isEncrypted)
+        self.assertEqual(resp_get.protocol, server.protocol)
+        self.assertEqual(resp_get.data, server.data)
+
+        self.assertEqual(req_post.srcPort, -1)
+        self.assertEqual(req_post.dstPort, server.port)
+        self.assertEqual(req_post.isEncrypted, server.isEncrypted)
+        self.assertEqual(req_post.protocol, server.protocol)
+        self.assertNotEqual(req_post.data, user.data)
+
+        self.assertEqual(resp_post.srcPort, server.port)
+        self.assertEqual(resp_post.dstPort, -1)
+        self.assertEqual(resp_post.isEncrypted, server.isEncrypted)
+        self.assertEqual(resp_post.protocol, server.protocol)
+        self.assertEqual(resp_post.data, server.data)


### PR DESCRIPTION
Allow Dataflows to inherit attribute values from their sources or sinks, if no value has been provided. This allows for even less code when building models, making them more readable. See the new test for examples.

Other changes include:
* ensure all elements have a port, isEncrypted, protocol and data attributes and removed duplicated attributes
* added isResponse and srcPort to Dataflows - currently isResponse only determines how Dataflow will inherit some attributes, either from source or sink
* changed the default 10000 port value to -1 which should represent a random port
* removed HandlesResources which looks like a typo, there's handlesResources already

Note that the port for the Actor was added mainly to avoid an extra `if hasattr(e.sink, "port"):`. It represents a source port for requests, which almost always is random or unknown. But it's totally optional, should not add any cognitive load for users.

Also note that removing `HandlesResources` is a breaking change, even if it was a typo. Next version should be 2.0, also because the `var` objects now throw exceptions if being overwritten.