### PR TITLE
Remove usage of global attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,6 @@ that periodically cleans the Database.
 
 from pytm.pytm import TM, Server, Datastore, Dataflow, Boundary, Actor, Lambda, Data, Classification
 
-tm = TM("my test tm")
-tm.description = "another test tm"
-tm.isOrdered = True
-
 User_Web = Boundary("User/Web")
 Web_DB = Boundary("Web/DB")
 
@@ -172,7 +168,10 @@ db_to_web.protocol = "MySQL"
 # will appear on the sample report. Use Data objects.
 db_to_web.data = 'Results of insert op'
 
-
+tm = TM("my test tm")
+tm.description = "another test tm"
+tm.isOrdered = True
+tm.elements = [my_lambda_to_db, user_to_web, web_to_user, web_to_db, db_to_web]
 tm.process()
 
 ```

--- a/README.md
+++ b/README.md
@@ -123,55 +123,56 @@ that periodically cleans the Database.
 
 from pytm.pytm import TM, Server, Datastore, Dataflow, Boundary, Actor, Lambda, Data, Classification
 
-User_Web = Boundary("User/Web")
-Web_DB = Boundary("Web/DB")
-
-user = Actor("User")
-user.inBoundary = User_Web
-
-web = Server("Web Server")
-web.OS = "CloudOS"
-web.isHardened = True
-web.sourceCode = "server/web.cc"
-
-db = Datastore("SQL Database (*)")
-db.OS = "CentOS"
-db.isHardened = False
-db.inBoundary = Web_DB
-db.isSql = True
-db.inScope = False
-db.sourceCode = "model/schema.sql"
-
-my_lambda = Lambda("cleanDBevery6hours")
-my_lambda.hasAccessControl = True
-my_lambda.inBoundary = Web_DB
-
-my_lambda_to_db = Dataflow(my_lambda, db, "(&lambda;)Periodically cleans DB")
-my_lambda_to_db.protocol = "SQL"
-my_lambda_to_db.dstPort = 3306
-
-user_to_web = Dataflow(user, web, "User enters comments (*)")
-user_to_web.protocol = "HTTP"
-user_to_web.dstPort = 80
-user_to_web.data = Data('Comments in HTML or Markdown', classification=Classification.PUBLIC)
-
-web_to_user = Dataflow(web, user, "Comments saved (*)")
-web_to_user.protocol = "HTTP"
-
-web_to_db = Dataflow(web, db, "Insert query with comments")
-web_to_db.protocol = "MySQL"
-web_to_db.dstPort = 3306
-
-db_to_web = Dataflow(db, web, "Comments contents")
-db_to_web.protocol = "MySQL"
-# this is a BAD way of defining a data object, here for a demo on how it
-# will appear on the sample report. Use Data objects.
-db_to_web.data = 'Results of insert op'
-
 tm = TM("my test tm")
 tm.description = "another test tm"
 tm.isOrdered = True
-tm.elements = [my_lambda_to_db, user_to_web, web_to_user, web_to_db, db_to_web]
+
+with tm.build():
+    User_Web = Boundary("User/Web")
+    Web_DB = Boundary("Web/DB")
+
+    user = Actor("User")
+    user.inBoundary = User_Web
+
+    web = Server("Web Server")
+    web.OS = "CloudOS"
+    web.isHardened = True
+    web.sourceCode = "server/web.cc"
+
+    db = Datastore("SQL Database (*)")
+    db.OS = "CentOS"
+    db.isHardened = False
+    db.inBoundary = Web_DB
+    db.isSql = True
+    db.inScope = False
+    db.sourceCode = "model/schema.sql"
+
+    my_lambda = Lambda("cleanDBevery6hours")
+    my_lambda.hasAccessControl = True
+    my_lambda.inBoundary = Web_DB
+
+    my_lambda_to_db = Dataflow(my_lambda, db, "(&lambda;)Periodically cleans DB")
+    my_lambda_to_db.protocol = "SQL"
+    my_lambda_to_db.dstPort = 3306
+
+    user_to_web = Dataflow(user, web, "User enters comments (*)")
+    user_to_web.protocol = "HTTP"
+    user_to_web.dstPort = 80
+    user_to_web.data = Data('Comments in HTML or Markdown', classification=Classification.PUBLIC)
+
+    web_to_user = Dataflow(web, user, "Comments saved (*)")
+    web_to_user.protocol = "HTTP"
+
+    web_to_db = Dataflow(web, db, "Insert query with comments")
+    web_to_db.protocol = "MySQL"
+    web_to_db.dstPort = 3306
+
+    db_to_web = Dataflow(db, web, "Comments contents")
+    db_to_web.protocol = "MySQL"
+    # this is a BAD way of defining a data object, here for a demo on how it
+    # will appear on the sample report. Use Data objects.
+    db_to_web.data = 'Results of insert op'
+
 tm.process()
 
 ```

--- a/pytm/json.py
+++ b/pytm/json.py
@@ -39,13 +39,13 @@ def decode(data):
 
     boundaries = decode_boundaries(data.pop("boundaries", []))
     elements = decode_elements(data.pop("elements", []), boundaries)
-    decode_flows(data.pop("flows", []), elements)
+    flows = decode_flows(data.pop("flows", []), elements)
 
     if "name" not in data:
         raise ValueError("name property missing for threat model")
     if "onDuplicates" in data:
         data["onDuplicates"] = Action(data["onDuplicates"])
-    return TM(data.pop("name"), **data)
+    return TM(data.pop("name"), elements=list(elements.values()) + flows, **data)
 
 
 def decode_boundaries(flat):
@@ -89,6 +89,7 @@ def decode_elements(flat, boundaries):
 
 
 def decode_flows(flat, elements):
+    flows = []
     for i, e in enumerate(flat):
         name = e.pop("name", None)
         if name is None:
@@ -103,4 +104,5 @@ def decode_flows(flat, elements):
         if e["sink"] not in elements:
             raise ValueError(f"dataflow {name} references invalid sink {e['sink']}")
         sink = elements[e.pop("sink")]
-        Dataflow(source, sink, name, **e)
+        flows.append(Dataflow(source, sink, name, **e))
+    return flows

--- a/tests/dfd.dot
+++ b/tests/dfd.dot
@@ -27,6 +27,36 @@ digraph tm {
             label = <<i>Company net</i>>;
         ]
 
+        subgraph cluster_boundary_backend_f2eb7a3ff7 {
+            graph [
+                fontsize = 10;
+                fontcolor = firebrick2;
+                style = dashed;
+                color = firebrick2;
+                label = <<i>backend</i>>;
+            ]
+
+            datastore_SQLDatabase_0291419f72 [
+                shape = none;
+                fixedsize = shape;
+                image = "INSTALL_PATH/pytm/images/datastore.png";
+                imagescale = true;
+                color = black;
+                fontcolor = black;
+                xlabel = "SQL Database";
+                label = "";
+            ]
+
+            server_WebServer_2c440ebe53 [
+                shape = circle;
+                color = black;
+                fontcolor = black;
+                label = "Web Server";
+                margin = 0.02;
+            ]
+
+        }
+
         subgraph cluster_boundary_dmz_579e9aae81 {
             graph [
                 fontsize = 10;
@@ -42,36 +72,6 @@ digraph tm {
                 fontcolor = black;
                 label = "Gateway";
                 margin = 0.02;
-            ]
-
-        }
-
-        subgraph cluster_boundary_backend_f2eb7a3ff7 {
-            graph [
-                fontsize = 10;
-                fontcolor = firebrick2;
-                style = dashed;
-                color = firebrick2;
-                label = <<i>backend</i>>;
-            ]
-
-            server_WebServer_2c440ebe53 [
-                shape = circle;
-                color = black;
-                fontcolor = black;
-                label = "Web Server";
-                margin = 0.02;
-            ]
-
-            datastore_SQLDatabase_0291419f72 [
-                shape = none;
-                fixedsize = shape;
-                image = "INSTALL_PATH/pytm/images/datastore.png";
-                imagescale = true;
-                color = black;
-                fontcolor = black;
-                xlabel = "SQL Database";
-                label = "";
             ]
 
         }
@@ -97,11 +97,11 @@ digraph tm {
 
     }
 
-    actor_User_d2006ce1bb -> server_Gateway_f8af758679 [
+    server_WebServer_2c440ebe53 -> datastore_SQLDatabase_0291419f72 [
         color = black;
         fontcolor = black;
         dir = forward;
-        label = "User enters\ncomments (*)";
+        label = "Insert query with\ncomments";
     ]
 
     server_Gateway_f8af758679 -> server_WebServer_2c440ebe53 [
@@ -111,11 +111,11 @@ digraph tm {
         label = "Request";
     ]
 
-    server_WebServer_2c440ebe53 -> datastore_SQLDatabase_0291419f72 [
+    server_WebServer_2c440ebe53 -> server_Gateway_f8af758679 [
         color = black;
         fontcolor = black;
         dir = forward;
-        label = "Insert query with\ncomments";
+        label = "Response";
     ]
 
     datastore_SQLDatabase_0291419f72 -> server_WebServer_2c440ebe53 [
@@ -125,18 +125,18 @@ digraph tm {
         label = "Retrieve comments";
     ]
 
-    server_WebServer_2c440ebe53 -> server_Gateway_f8af758679 [
-        color = black;
-        fontcolor = black;
-        dir = forward;
-        label = "Response";
-    ]
-
     server_Gateway_f8af758679 -> actor_User_d2006ce1bb [
         color = black;
         fontcolor = black;
         dir = forward;
         label = "Show comments (*)";
+    ]
+
+    actor_User_d2006ce1bb -> server_Gateway_f8af758679 [
+        color = black;
+        fontcolor = black;
+        dir = forward;
+        label = "User enters\ncomments (*)";
     ]
 
 }

--- a/tests/dfd_level0.txt
+++ b/tests/dfd_level0.txt
@@ -67,13 +67,6 @@ digraph tm {
         margin = 0.02;
     ]
 
-    actor_User_579e9aae81 -> server_WebServer_f2eb7a3ff7 [
-        color = black;
-        fontcolor = black;
-        dir = forward;
-        label = "User enters\ncomments (*)";
-    ]
-
     server_WebServer_f2eb7a3ff7 -> datastore_SQLDatabase_d2006ce1bb [
         color = black;
         fontcolor = black;
@@ -93,6 +86,13 @@ digraph tm {
         fontcolor = black;
         dir = forward;
         label = "Show comments (*)";
+    ]
+
+    actor_User_579e9aae81 -> server_WebServer_f2eb7a3ff7 [
+        color = black;
+        fontcolor = black;
+        dir = forward;
+        label = "User enters\ncomments (*)";
     ]
 
 }

--- a/tests/output.json
+++ b/tests/output.json
@@ -98,7 +98,7 @@
         },
         {
             "OS": "",
-            "__class__": "Lambda",
+            "__class__": "Datastore",
             "authenticatesDestination": false,
             "authenticatesSource": false,
             "authenticationScheme": "",
@@ -109,35 +109,49 @@
             "definesConnectionTimeout": false,
             "description": "",
             "encodesOutput": false,
-            "environment": "",
             "findings": [],
+            "handlesInterruptions": false,
             "handlesResourceConsumption": false,
             "handlesResources": false,
             "hasAccessControl": false,
-            "implementsAPI": false,
+            "hasWriteAccess": false,
             "implementsAuthenticationScheme": false,
             "implementsNonce": false,
-            "inBoundary": null,
+            "implementsPOLP": false,
+            "inBoundary": "Server/DB",
             "inScope": true,
             "inputs": [
-                "Call func"
+                "Insert query with comments",
+                "Query for tasks"
             ],
             "isEncrypted": false,
+            "isEncryptedAtRest": false,
             "isHardened": false,
+            "isResilient": false,
+            "isSQL": true,
+            "isShared": false,
             "levels": [
                 0
             ],
             "maxClassification": "Classification.UNKNOWN",
             "minTLSVersion": "TLSVersion.NONE",
-            "name": "Lambda func",
-            "onAWS": true,
-            "outputs": [],
+            "name": "SQL Database",
+            "onAWS": false,
+            "onRDS": false,
+            "outputs": [
+                "Retrieve comments"
+            ],
             "overrides": [],
             "port": -1,
             "protocol": "",
+            "providesConfidentiality": false,
             "providesIntegrity": false,
             "sanitizesInput": false,
             "sourceFiles": [],
+            "storesLogData": false,
+            "storesPII": false,
+            "storesSensitiveData": false,
+            "usesEncryptionAlgorithm": "",
             "usesEnvironmentVariables": false,
             "validatesInput": false
         },
@@ -206,7 +220,7 @@
         },
         {
             "OS": "",
-            "__class__": "Datastore",
+            "__class__": "Lambda",
             "authenticatesDestination": false,
             "authenticatesSource": false,
             "authenticationScheme": "",
@@ -217,49 +231,35 @@
             "definesConnectionTimeout": false,
             "description": "",
             "encodesOutput": false,
+            "environment": "",
             "findings": [],
-            "handlesInterruptions": false,
             "handlesResourceConsumption": false,
             "handlesResources": false,
             "hasAccessControl": false,
-            "hasWriteAccess": false,
+            "implementsAPI": false,
             "implementsAuthenticationScheme": false,
             "implementsNonce": false,
-            "implementsPOLP": false,
-            "inBoundary": "Server/DB",
+            "inBoundary": null,
             "inScope": true,
             "inputs": [
-                "Insert query with comments",
-                "Query for tasks"
+                "Call func"
             ],
             "isEncrypted": false,
-            "isEncryptedAtRest": false,
             "isHardened": false,
-            "isResilient": false,
-            "isSQL": true,
-            "isShared": false,
             "levels": [
                 0
             ],
             "maxClassification": "Classification.UNKNOWN",
             "minTLSVersion": "TLSVersion.NONE",
-            "name": "SQL Database",
-            "onAWS": false,
-            "onRDS": false,
-            "outputs": [
-                "Retrieve comments"
-            ],
+            "name": "Lambda func",
+            "onAWS": true,
+            "outputs": [],
             "overrides": [],
             "port": -1,
             "protocol": "",
-            "providesConfidentiality": false,
             "providesIntegrity": false,
             "sanitizesInput": false,
             "sourceFiles": [],
-            "storesLogData": false,
-            "storesPII": false,
-            "storesSensitiveData": false,
-            "usesEncryptionAlgorithm": "",
             "usesEnvironmentVariables": false,
             "validatesInput": false
         }
@@ -267,6 +267,9 @@
     "boundaries": [
         {
             "description": "",
+            "elements": [
+                "User"
+            ],
             "findings": [],
             "inBoundary": null,
             "inScope": true,
@@ -281,6 +284,9 @@
         },
         {
             "description": "",
+            "elements": [
+                "SQL Database"
+            ],
             "findings": [],
             "inBoundary": null,
             "inScope": true,
@@ -294,6 +300,7 @@
             "sourceFiles": []
         }
     ],
+    "contexts": [],
     "data": [
         {
             "carriedBy": [
@@ -413,7 +420,7 @@
         },
         {
             "OS": "",
-            "__class__": "Lambda",
+            "__class__": "Datastore",
             "authenticatesDestination": false,
             "authenticatesSource": false,
             "authenticationScheme": "",
@@ -424,35 +431,49 @@
             "definesConnectionTimeout": false,
             "description": "",
             "encodesOutput": false,
-            "environment": "",
             "findings": [],
+            "handlesInterruptions": false,
             "handlesResourceConsumption": false,
             "handlesResources": false,
             "hasAccessControl": false,
-            "implementsAPI": false,
+            "hasWriteAccess": false,
             "implementsAuthenticationScheme": false,
             "implementsNonce": false,
-            "inBoundary": null,
+            "implementsPOLP": false,
+            "inBoundary": "Server/DB",
             "inScope": true,
             "inputs": [
-                "Call func"
+                "Insert query with comments",
+                "Query for tasks"
             ],
             "isEncrypted": false,
+            "isEncryptedAtRest": false,
             "isHardened": false,
+            "isResilient": false,
+            "isSQL": true,
+            "isShared": false,
             "levels": [
                 0
             ],
             "maxClassification": "Classification.UNKNOWN",
             "minTLSVersion": "TLSVersion.NONE",
-            "name": "Lambda func",
-            "onAWS": true,
-            "outputs": [],
+            "name": "SQL Database",
+            "onAWS": false,
+            "onRDS": false,
+            "outputs": [
+                "Retrieve comments"
+            ],
             "overrides": [],
             "port": -1,
             "protocol": "",
+            "providesConfidentiality": false,
             "providesIntegrity": false,
             "sanitizesInput": false,
             "sourceFiles": [],
+            "storesLogData": false,
+            "storesPII": false,
+            "storesSensitiveData": false,
+            "usesEncryptionAlgorithm": "",
             "usesEnvironmentVariables": false,
             "validatesInput": false
         },
@@ -521,7 +542,7 @@
         },
         {
             "OS": "",
-            "__class__": "Datastore",
+            "__class__": "Lambda",
             "authenticatesDestination": false,
             "authenticatesSource": false,
             "authenticationScheme": "",
@@ -532,49 +553,35 @@
             "definesConnectionTimeout": false,
             "description": "",
             "encodesOutput": false,
+            "environment": "",
             "findings": [],
-            "handlesInterruptions": false,
             "handlesResourceConsumption": false,
             "handlesResources": false,
             "hasAccessControl": false,
-            "hasWriteAccess": false,
+            "implementsAPI": false,
             "implementsAuthenticationScheme": false,
             "implementsNonce": false,
-            "implementsPOLP": false,
-            "inBoundary": "Server/DB",
+            "inBoundary": null,
             "inScope": true,
             "inputs": [
-                "Insert query with comments",
-                "Query for tasks"
+                "Call func"
             ],
             "isEncrypted": false,
-            "isEncryptedAtRest": false,
             "isHardened": false,
-            "isResilient": false,
-            "isSQL": true,
-            "isShared": false,
             "levels": [
                 0
             ],
             "maxClassification": "Classification.UNKNOWN",
             "minTLSVersion": "TLSVersion.NONE",
-            "name": "SQL Database",
-            "onAWS": false,
-            "onRDS": false,
-            "outputs": [
-                "Retrieve comments"
-            ],
+            "name": "Lambda func",
+            "onAWS": true,
+            "outputs": [],
             "overrides": [],
             "port": -1,
             "protocol": "",
-            "providesConfidentiality": false,
             "providesIntegrity": false,
             "sanitizesInput": false,
             "sourceFiles": [],
-            "storesLogData": false,
-            "storesPII": false,
-            "storesSensitiveData": false,
-            "usesEncryptionAlgorithm": "",
             "usesEnvironmentVariables": false,
             "validatesInput": false
         }
@@ -794,7 +801,6 @@
             "usesVPN": false
         }
     ],
-    "ignoreUnused": false,
     "isOrdered": true,
     "mergeResponses": false,
     "name": "my test tm",

--- a/tests/test_pytmfunc.py
+++ b/tests/test_pytmfunc.py
@@ -42,20 +42,20 @@ class TestTM(unittest.TestCase):
         with open(os.path.join(dir_path, "seq.plantuml")) as x:
             expected = x.read().strip()
 
-        TM.reset()
-        tm = TM("my test tm", description="aaa")
-        tm.isOrdered = True
         internet = Boundary("Internet")
         server_db = Boundary("Server/DB")
         user = Actor("User", inBoundary=internet)
         web = Server("Web Server")
         db = Datastore("SQL Database", inBoundary=server_db)
 
-        Dataflow(user, web, "User enters comments (*)", note="bbb")
-        Dataflow(web, db, "Insert query with comments", note="ccc")
-        Dataflow(db, web, "Retrieve comments")
-        Dataflow(web, user, "Show comments (*)")
+        flows = [
+            Dataflow(user, web, "User enters comments (*)", note="bbb"),
+            Dataflow(web, db, "Insert query with comments", note="ccc"),
+            Dataflow(db, web, "Retrieve comments"),
+            Dataflow(web, user, "Show comments (*)"),
+        ]
 
+        tm = TM("my test tm", description="aaa", elements=flows, isOrdered=True)
         self.assertTrue(tm.check())
         output = tm.seq()
 
@@ -68,8 +68,6 @@ class TestTM(unittest.TestCase):
         with open(os.path.join(dir_path, "seq_unused.plantuml")) as x:
             expected = x.read().strip()
 
-        TM.reset()
-        tm = TM("my test tm", description="aaa", ignoreUnused=True)
         internet = Boundary("Internet")
         server_db = Boundary("Server/DB")
         user = Actor("User", inBoundary=internet)
@@ -77,11 +75,14 @@ class TestTM(unittest.TestCase):
         db = Datastore("SQL Database", inBoundary=server_db)
         Lambda("Unused Lambda")
 
-        Dataflow(user, web, "User enters comments (*)", note="bbb")
-        Dataflow(web, db, "Insert query with comments", note="ccc")
-        Dataflow(db, web, "Retrieve comments")
-        Dataflow(web, user, "Show comments (*)")
+        flows = [
+            Dataflow(user, web, "User enters comments (*)", note="bbb"),
+            Dataflow(web, db, "Insert query with comments", note="ccc"),
+            Dataflow(db, web, "Retrieve comments"),
+            Dataflow(web, user, "Show comments (*)"),
+        ]
 
+        tm = TM("my test tm", description="aaa", elements=flows)
         self.assertTrue(tm.check())
         output = tm.seq()
 
@@ -99,8 +100,6 @@ class TestTM(unittest.TestCase):
 
         random.seed(0)
 
-        TM.reset()
-        tm = TM("my test tm", description="aaa")
         internet = Boundary("Internet")
         net = Boundary("Company net")
         dmz = Boundary("dmz", inBoundary=net)
@@ -111,13 +110,16 @@ class TestTM(unittest.TestCase):
         db = Datastore("SQL Database", inBoundary=backend, isEncryptedAtRest=True)
         comment = Data("Comment", isStored=True)
 
-        Dataflow(user, gw, "User enters comments (*)")
-        Dataflow(gw, web, "Request")
-        Dataflow(web, db, "Insert query with comments", data=[comment])
-        Dataflow(db, web, "Retrieve comments")
-        Dataflow(web, gw, "Response")
-        Dataflow(gw, user, "Show comments (*)")
+        flows = [
+            Dataflow(user, gw, "User enters comments (*)"),
+            Dataflow(gw, web, "Request"),
+            Dataflow(web, db, "Insert query with comments", data=[comment]),
+            Dataflow(db, web, "Retrieve comments"),
+            Dataflow(web, gw, "Response"),
+            Dataflow(gw, user, "Show comments (*)"),
+        ]
 
+        tm = TM("my test tm", description="aaa", elements=flows)
         self.assertTrue(tm.check())
         output = tm.dfd()
 
@@ -134,8 +136,6 @@ class TestTM(unittest.TestCase):
 
         random.seed(0)
 
-        TM.reset()
-        tm = TM("my test tm", description="aaa", onDuplicates=Action.IGNORE)
         internet = Boundary("Internet")
         net = Boundary("Company net")
         dmz = Boundary("dmz", inBoundary=net)
@@ -145,15 +145,20 @@ class TestTM(unittest.TestCase):
         web = Server("Web Server", inBoundary=backend)
         db = Datastore("SQL Database", inBoundary=backend)
 
-        Dataflow(user, gw, "User enters comments (*)")
-        Dataflow(user, gw, "User views comments")
-        Dataflow(gw, web, "Request")
-        Dataflow(web, db, "Insert query with comments")
-        Dataflow(web, db, "Select query")
-        Dataflow(db, web, "Retrieve comments")
-        Dataflow(web, gw, "Response")
-        Dataflow(gw, user, "Show comments (*)")
+        flows = [
+            Dataflow(user, gw, "User enters comments (*)"),
+            Dataflow(user, gw, "User views comments"),
+            Dataflow(gw, web, "Request"),
+            Dataflow(web, db, "Insert query with comments"),
+            Dataflow(web, db, "Select query"),
+            Dataflow(db, web, "Retrieve comments"),
+            Dataflow(web, gw, "Response"),
+            Dataflow(gw, user, "Show comments (*)"),
+        ]
 
+        tm = TM(
+            "my test tm", description="aaa", onDuplicates=Action.IGNORE, elements=flows
+        )
         self.assertTrue(tm.check())
         output = tm.dfd()
 
@@ -163,20 +168,27 @@ class TestTM(unittest.TestCase):
     def test_dfd_duplicates_raise(self):
         random.seed(0)
 
-        TM.reset()
-        tm = TM("my test tm", description="aaa", onDuplicates=Action.RESTRICT)
         internet = Boundary("Internet")
         server_db = Boundary("Server/DB")
         user = Actor("User", inBoundary=internet)
         web = Server("Web Server")
         db = Datastore("SQL Database", inBoundary=server_db)
 
-        Dataflow(user, web, "User enters comments (*)")
-        Dataflow(user, web, "User views comments")
-        Dataflow(web, db, "Insert query with comments")
-        Dataflow(web, db, "Select query")
-        Dataflow(db, web, "Retrieve comments")
-        Dataflow(web, user, "Show comments (*)")
+        flows = [
+            Dataflow(user, web, "User enters comments (*)"),
+            Dataflow(user, web, "User views comments"),
+            Dataflow(web, db, "Insert query with comments"),
+            Dataflow(web, db, "Select query"),
+            Dataflow(db, web, "Retrieve comments"),
+            Dataflow(web, user, "Show comments (*)"),
+        ]
+
+        tm = TM(
+            "my test tm",
+            description="aaa",
+            onDuplicates=Action.RESTRICT,
+            elements=flows,
+        )
 
         e = re.escape(
             "Duplicate Dataflow found between Actor(User) "
@@ -189,8 +201,6 @@ class TestTM(unittest.TestCase):
     def test_resolve(self):
         random.seed(0)
 
-        TM.reset()
-        tm = TM("my test tm", description="aaa")
         internet = Boundary("Internet")
         server_db = Boundary("Server/DB")
         user = Actor("User", inBoundary=internet, inScope=False)
@@ -202,7 +212,8 @@ class TestTM(unittest.TestCase):
         results = Dataflow(db, web, "Retrieve comments")
         resp = Dataflow(web, user, "Show comments (*)")
 
-        TM._threats = [
+        tm = TM("my test tm", description="aaa", elements=[req, query, results, resp])
+        tm._threats = [
             Threat(SID=klass, target=klass)
             for klass in ["Actor", "Server", "Datastore", "Dataflow"]
         ]
@@ -211,7 +222,7 @@ class TestTM(unittest.TestCase):
         self.maxDiff = None
         self.assertEqual(
             [f.threat_id for f in tm.findings],
-            ["Server", "Datastore", "Dataflow", "Dataflow", "Dataflow", "Dataflow"],
+            ["Datastore", "Server", "Dataflow", "Dataflow", "Dataflow", "Dataflow"],
         )
         self.assertEqual([f.threat_id for f in user.findings], [])
         self.assertEqual([f.threat_id for f in web.findings], ["Server"])
@@ -224,8 +235,6 @@ class TestTM(unittest.TestCase):
     def test_overrides(self):
         random.seed(0)
 
-        TM.reset()
-        tm = TM("my test tm", description="aaa")
         internet = Boundary("Internet")
         server_db = Boundary("Server/DB")
         user = Actor("User", inBoundary=internet, inScope=False)
@@ -251,7 +260,8 @@ class TestTM(unittest.TestCase):
         results = Dataflow(db, web, "Retrieve comments")
         resp = Dataflow(web, user, "Show comments (*)")
 
-        TM._threats = [
+        tm = TM("my test tm", description="aaa", elements=[req, query, results, resp])
+        tm._threats = [
             Threat(SID="Server", target="Server", condition="False"),
             Threat(SID="Datastore", target="Datastore"),
         ]
@@ -260,7 +270,7 @@ class TestTM(unittest.TestCase):
         self.maxDiff = None
         self.assertEqual(
             [f.threat_id for f in tm.findings],
-            ["Server", "Datastore"],
+            ["Datastore", "Server"],
         )
         self.assertEqual(
             [f.response for f in web.findings], ["mitigated by adding TLS"]
@@ -275,11 +285,6 @@ class TestTM(unittest.TestCase):
         dir_path = os.path.dirname(os.path.realpath(__file__))
         with open(os.path.join(dir_path, "output.json")) as x:
             expected = x.read().strip()
-        TM.reset()
-        tm = TM(
-            "my test tm", description="aaa", threatsFile="pytm/threatlib/threats.json"
-        )
-        tm.isOrdered = True
         internet = Boundary("Internet")
         server_db = Boundary("Server/DB")
         user = Actor("User", inBoundary=internet)
@@ -293,13 +298,22 @@ class TestTM(unittest.TestCase):
             description="auth cookie description",
             classification=Classification.PUBLIC,
         )
-        Dataflow(user, web, "User enters comments (*)", note="bbb", data=cookie)
-        Dataflow(web, db, "Insert query with comments", note="ccc")
-        Dataflow(web, func, "Call func")
-        Dataflow(db, web, "Retrieve comments")
-        Dataflow(web, user, "Show comments (*)")
-        Dataflow(worker, db, "Query for tasks")
+        flows = [
+            Dataflow(user, web, "User enters comments (*)", note="bbb", data=cookie),
+            Dataflow(web, db, "Insert query with comments", note="ccc"),
+            Dataflow(web, func, "Call func"),
+            Dataflow(db, web, "Retrieve comments"),
+            Dataflow(web, user, "Show comments (*)"),
+            Dataflow(worker, db, "Query for tasks"),
+        ]
 
+        tm = TM(
+            "my test tm",
+            description="aaa",
+            threatsFile="pytm/threatlib/threats.json",
+            isOrdered=True,
+            elements=flows,
+        )
         self.assertTrue(tm.check())
         output = json.dumps(tm, default=to_serializable, sort_keys=True, indent=4)
 
@@ -315,7 +329,6 @@ class TestTM(unittest.TestCase):
         with open(os.path.join(dir_path, "input.json")) as x:
             contents = x.read().strip()
 
-        TM.reset()
         tm = loads(contents)
         self.assertTrue(tm.check())
 
@@ -324,11 +337,11 @@ class TestTM(unittest.TestCase):
         self.assertEqual(
             [e.name for e in tm._elements],
             [
-                "Internet",
-                "Server/DB",
                 "User",
                 "Web Server",
                 "SQL Database",
+                "Internet",
+                "Server/DB",
                 "Request",
                 "Insert",
                 "Select",
@@ -345,11 +358,6 @@ class TestTM(unittest.TestCase):
         with open(os.path.join(dir_path, "output.md")) as x:
             expected = x.read().strip()
 
-        TM.reset()
-        tm = TM(
-            "my test tm", description="aaa", threatsFile="pytm/threatlib/threats.json"
-        )
-        tm.isOrdered = True
         internet = Boundary("Internet")
         server_db = Boundary("Server/DB")
         user = Actor("User", inBoundary=internet)
@@ -363,13 +371,22 @@ class TestTM(unittest.TestCase):
             description="auth cookie description",
             classification=Classification.PUBLIC,
         )
-        Dataflow(user, web, "User enters comments (*)", note="bbb", data=cookie)
-        Dataflow(web, db, "Insert query with comments", note="ccc")
-        Dataflow(web, func, "Call func")
-        Dataflow(db, web, "Retrieve comments")
-        Dataflow(web, user, "Show comments (*)")
-        Dataflow(worker, db, "Query for tasks")
+        flows = [
+            Dataflow(user, web, "User enters comments (*)", note="bbb", data=cookie),
+            Dataflow(web, db, "Insert query with comments", note="ccc"),
+            Dataflow(web, func, "Call func"),
+            Dataflow(db, web, "Retrieve comments"),
+            Dataflow(web, user, "Show comments (*)"),
+            Dataflow(worker, db, "Query for tasks"),
+        ]
 
+        tm = TM(
+            "my test tm",
+            description="aaa",
+            threatsFile="pytm/threatlib/threats.json",
+            isOrdered=True,
+            elements=flows,
+        )
         self.assertTrue(tm.check())
         output = tm.report("docs/template.md")
 
@@ -390,38 +407,39 @@ class TestTM(unittest.TestCase):
                 x.read().strip().replace("INSTALL_PATH", os.path.dirname(install_path))
             )
 
-        TM.reset()
-        tm = TM("my test tm", description="aaa")
-        tm.isOrdered = False
         internet = Boundary("Internet")
         server_db = Boundary("Server/DB")
         user = Actor("User", inBoundary=internet, levels=0)
         web = Server("Web Server")
         db = Datastore("SQL Database", inBoundary=server_db)
-        Dataflow(user, web, "User enters comments (*)", note="bbb")
-        Dataflow(web, db, "Insert query with comments", note="ccc")
-        Dataflow(db, web, "Retrieve comments")
-        Dataflow(web, user, "Show comments (*)")
+        flows = [
+            Dataflow(user, web, "User enters comments (*)", note="bbb"),
+            Dataflow(web, db, "Insert query with comments", note="ccc"),
+            Dataflow(db, web, "Retrieve comments"),
+            Dataflow(web, user, "Show comments (*)"),
+        ]
 
+        tm = TM("my test tm", description="aaa", isOrdered=False, elements=flows)
         self.assertTrue(tm.check())
         output = tm.dfd(levels={0})
         with open(os.path.join(dir_path, "0.txt"), "w") as x:
             x.write(output)
+        self.maxDiff = None
         self.assertEqual(output, level_0)
 
-        TM.reset()
-        tm = TM("my test tm", description="aaa")
-        tm.isOrdered = False
         internet = Boundary("Internet")
         server_db = Boundary("Server/DB")
         user = Actor("User", inBoundary=internet, levels=1)
         web = Server("Web Server")
         db = Datastore("SQL Database", inBoundary=server_db)
-        Dataflow(user, web, "User enters comments (*)", note="bbb")
-        Dataflow(web, db, "Insert query with comments", note="ccc")
-        Dataflow(db, web, "Retrieve comments")
-        Dataflow(web, user, "Show comments (*)")
+        flows = [
+            Dataflow(user, web, "User enters comments (*)", note="bbb"),
+            Dataflow(web, db, "Insert query with comments", note="ccc"),
+            Dataflow(db, web, "Retrieve comments"),
+            Dataflow(web, user, "Show comments (*)"),
+        ]
 
+        tm = TM("my test tm", description="aaa", isOrdered=False, elements=flows)
         self.assertTrue(tm.check())
         output = tm.dfd(levels={1})
         with open(os.path.join(dir_path, "1.txt"), "w") as x:
@@ -429,8 +447,154 @@ class TestTM(unittest.TestCase):
         self.maxDiff = None
         self.assertEqual(output, level_1)
 
+    def test_lazy_init(self):
+        internet = Boundary("Internet")
+        server_db = Boundary("Server/DB")
+        vpc = Boundary("AWS VPC")
 
-class Testpytm(unittest.TestCase):
+        user = Actor("User")
+        user.protocol = "HTTP"
+        user.inBoundary = internet
+
+        web = Server("Web Server")
+        web.OS = "Ubuntu"
+        web.protocol = "HTTP"
+        web.dstPort = 80
+        web.isHardened = True
+        web.sanitizesInput = False
+        web.encodesOutput = True
+        web.authorizesSource = False
+
+        db = Datastore("SQL Database")
+        db.OS = "CentOS"
+        db.protocol = "MySQL"
+        db.dstPort = 3306
+        db.isHardened = False
+        db.inBoundary = server_db
+        db.isSQL = True
+        db.inScope = True
+
+        my_lambda = Lambda("AWS Lambda")
+        my_lambda.hasAccessControl = True
+        my_lambda.inBoundary = vpc
+
+        user_to_web = Dataflow(user, web, "User enters comments (*)")
+        user_to_web.data = "Comments in HTML or Markdown"
+        user_to_web.note = "This is a simple web app."
+
+        web_to_db = Dataflow(web, db, "Insert query with comments")
+        web_to_db.data = "MySQL insert statement, all literals"
+        web_to_db.note = "Web server inserts user comments."
+
+        db_to_web = Dataflow(db, web, "Retrieve comments")
+        db_to_web.protocol = "MySQL"
+        db_to_web.data = "Web server retrieves comments from DB"
+
+        web_to_user = Dataflow(web, user, "Show comments (*)")
+        web_to_user.data = "Web server shows comments to the end user"
+
+        my_lambda_to_db = Dataflow(my_lambda, db, "Lambda periodically cleans DB")
+        my_lambda_to_db.data = "Lamda clears DB every 6 hours"
+
+        tm = TM("my test tm")
+        tm.description = "desc"
+        tm.isOrdered = True
+        tm.elements = [user_to_web, web_to_db, db_to_web, web_to_user, my_lambda_to_db]
+
+        assets = [user, web, db, my_lambda]
+        dataflows = [user_to_web, web_to_db, db_to_web, web_to_user, my_lambda_to_db]
+        boundaries = [vpc, internet, server_db]
+        self.assertTrue(tm.check())
+        self.maxDiff = None
+        self.assertListEqual(tm._elements, assets + boundaries + dataflows)
+        self.assertListEqual(tm._boundaries, [internet, server_db, vpc])
+        self.assertListEqual(tm._flows, dataflows)
+
+        assets = [user, web, db, my_lambda]
+        dataflows = [user_to_web, web_to_db, db_to_web, web_to_user, my_lambda_to_db]
+        boundaries = [vpc, internet, server_db]
+        self.assertTrue(tm.check())
+        self.maxDiff = None
+        self.assertListEqual(tm._elements, assets + boundaries + dataflows)
+        self.assertListEqual(tm._boundaries, [internet, server_db, vpc])
+        self.assertListEqual(tm._flows, dataflows)
+
+    def test_eager_init(self):
+        user = Actor("User", protocol="HTTP")
+        web = Server(
+            "Web Server",
+            OS="Ubuntu",
+            protocol="HTTP",
+            dstPort=80,
+            isHardened=True,
+            sanitizesInput=False,
+            encodesOutput=True,
+            authorizesSource=False,
+        )
+        db = Datastore(
+            "SQL Database",
+            OS="CentOS",
+            protocol="MySQL",
+            dstPort=3306,
+            isHardened=False,
+            isSQL=True,
+        )
+        my_lambda = Lambda("AWS Lambda", hasAccessControl=True)
+
+        elements = [
+            Boundary("AWS VPC", elements=[my_lambda]),
+            Boundary("Internet", elements=[user]),
+            Boundary("Server/DB", elements=[web, db]),
+            Dataflow(
+                user,
+                web,
+                "User enters comments (*)",
+                data="Comments in HTML or Markdown",
+                note="This is a simple web app.",
+            ),
+            Dataflow(
+                web,
+                db,
+                "Insert query with comments",
+                data="MySQL insert statement, all literals",
+                note="Web server inserts user comments.",
+            ),
+            Dataflow(
+                db,
+                web,
+                "Retrieve comments",
+                protocol="MySQL",
+                data="Web server retrieves comments from DB",
+            ),
+            Dataflow(
+                web,
+                user,
+                "Show comments (*)",
+                data="Web server shows comments to the end user",
+            ),
+            Dataflow(
+                my_lambda,
+                db,
+                "Lambda periodically cleans DB",
+                data="Lamda clears DB every 6 hours",
+            ),
+        ]
+
+        tm = TM(
+            "my test tm",
+            description="desc",
+            isOrdered=True,
+            elements=elements,
+        )
+
+        assets = [user, web, db, my_lambda]
+        self.assertTrue(tm.check())
+        self.assertListEqual(tm._elements, assets + elements)
+        self.assertEqual(len(tm._boundaries), 3)
+        self.assertEqual(len(tm._flows), 5)
+
+
+class TestThreats(unittest.TestCase):
     # Test for all the threats in threats.py - test Threat.apply() function
 
     def test_INP01(self):

--- a/tm.py
+++ b/tm.py
@@ -12,11 +12,6 @@ from pytm import (
     Server,
 )
 
-tm = TM("my test tm")
-tm.description = "This is a sample threat model of a very simple system - a web-based comment system. The user enters comments and these are added to a database and displayed back to the user. The thought is that it is, though simple, a complete enough example to express meaningful threats."
-tm.isOrdered = True
-tm.mergeResponses = True
-
 internet = Boundary("Internet")
 server_db = Boundary("Server/DB")
 server_db.levels = [2]
@@ -117,6 +112,14 @@ userIdToken = Data(
     processedBy=[db, secretDb],
 )
 
+tm = TM("my test tm")
+tm.description = """This is a sample threat model of a very simple system - a web-based
+comment system. The user enters comments and these are added to a database and displayed
+back to the user. The thought is that it is, though simple, a complete enough example
+to express meaningful threats."""
+tm.isOrdered = True
+tm.mergeResponses = True
+tm.elements = [user_to_web, web_to_db, db_to_web, web_to_user, my_lambda_to_db]
 
 if __name__ == "__main__":
     tm.process()

--- a/tm.py
+++ b/tm.py
@@ -12,106 +12,6 @@ from pytm import (
     Server,
 )
 
-internet = Boundary("Internet")
-server_db = Boundary("Server/DB")
-server_db.levels = [2]
-vpc = Boundary("AWS VPC")
-
-user = Actor("User")
-user.inBoundary = internet
-user.levels = [2]
-
-web = Server("Web Server")
-web.OS = "Ubuntu"
-web.isHardened = True
-web.sanitizesInput = False
-web.encodesOutput = True
-web.authorizesSource = False
-web.sourceFiles = ["pytm/json.py", "docs/template.md"]
-
-db = Datastore("SQL Database")
-db.OS = "CentOS"
-db.isHardened = False
-db.inBoundary = server_db
-db.isSQL = True
-db.inScope = True
-db.maxClassification = Classification.RESTRICTED
-db.levels = [2]
-
-secretDb = Datastore("Real Identity Database")
-secretDb.OS = "CentOS"
-secretDb.sourceFiles = ["pytm/pytm.py"]
-secretDb.isHardened = True
-secretDb.inBoundary = server_db
-secretDb.isSQL = True
-secretDb.inScope = True
-secretDb.storesPII = True
-secretDb.maxClassification = Classification.TOP_SECRET
-
-my_lambda = Lambda("AWS Lambda")
-my_lambda.hasAccessControl = True
-my_lambda.inBoundary = vpc
-my_lambda.levels = [1, 2]
-
-token_user_identity = Data(
-    "Token verifying user identity", classification=Classification.SECRET
-)
-db_to_secretDb = Dataflow(db, secretDb, "Database verify real user identity")
-db_to_secretDb.protocol = "RDA-TCP"
-db_to_secretDb.dstPort = 40234
-db_to_secretDb.data = token_user_identity
-db_to_secretDb.note = "Verifying that the user is who they say they are."
-db_to_secretDb.maxClassification = Classification.SECRET
-
-comments_in_text = Data(
-    "Comments in HTML or Markdown", classification=Classification.PUBLIC
-)
-user_to_web = Dataflow(user, web, "User enters comments (*)")
-user_to_web.protocol = "HTTP"
-user_to_web.dstPort = 80
-user_to_web.data = comments_in_text
-user_to_web.note = "This is a simple web app\nthat stores and retrieves user comments."
-
-query_insert = Data("Insert query with comments", classification=Classification.PUBLIC)
-web_to_db = Dataflow(web, db, "Insert query with comments")
-web_to_db.protocol = "MySQL"
-web_to_db.dstPort = 3306
-web_to_db.data = query_insert
-web_to_db.note = (
-    "Web server inserts user comments\ninto it's SQL query and stores them in the DB."
-)
-
-comment_retrieved = Data(
-    "Web server retrieves comments from DB", classification=Classification.PUBLIC
-)
-db_to_web = Dataflow(db, web, "Retrieve comments")
-db_to_web.protocol = "MySQL"
-db_to_web.dstPort = 80
-db_to_web.data = comment_retrieved
-db_to_web.responseTo = web_to_db
-
-comment_to_show = Data(
-    "Web server shows comments to the end user", classifcation=Classification.PUBLIC
-)
-web_to_user = Dataflow(web, user, "Show comments (*)")
-web_to_user.protocol = "HTTP"
-web_to_user.data = comment_to_show
-web_to_user.responseTo = user_to_web
-
-clear_op = Data("Serverless function clears DB", classification=Classification.PUBLIC)
-my_lambda_to_db = Dataflow(my_lambda, db, "Serverless function periodically cleans DB")
-my_lambda_to_db.protocol = "MySQL"
-my_lambda_to_db.dstPort = 3306
-my_lambda_to_db.data = clear_op
-
-userIdToken = Data(
-    name="User ID Token",
-    description="Some unique token that represents the user real data in the secret database",
-    classification=Classification.TOP_SECRET,
-    traverses=[user_to_web, db_to_secretDb],
-    processedBy=[db, secretDb],
-)
-
 tm = TM("my test tm")
 tm.description = """This is a sample threat model of a very simple system - a web-based
 comment system. The user enters comments and these are added to a database and displayed
@@ -119,7 +19,118 @@ back to the user. The thought is that it is, though simple, a complete enough ex
 to express meaningful threats."""
 tm.isOrdered = True
 tm.mergeResponses = True
-tm.elements = [user_to_web, web_to_db, db_to_web, web_to_user, my_lambda_to_db]
+
+with tm.build():
+    internet = Boundary("Internet")
+    server_db = Boundary("Server/DB")
+    server_db.levels = [2]
+    vpc = Boundary("AWS VPC")
+
+    user = Actor("User")
+    user.inBoundary = internet
+    user.levels = [2]
+
+    web = Server("Web Server")
+    web.OS = "Ubuntu"
+    web.isHardened = True
+    web.sanitizesInput = False
+    web.encodesOutput = True
+    web.authorizesSource = False
+    web.sourceFiles = ["pytm/json.py", "docs/template.md"]
+
+    db = Datastore("SQL Database")
+    db.OS = "CentOS"
+    db.isHardened = False
+    db.inBoundary = server_db
+    db.isSQL = True
+    db.inScope = True
+    db.maxClassification = Classification.RESTRICTED
+    db.levels = [2]
+
+    secretDb = Datastore("Real Identity Database")
+    secretDb.OS = "CentOS"
+    secretDb.sourceFiles = ["pytm/pytm.py"]
+    secretDb.isHardened = True
+    secretDb.inBoundary = server_db
+    secretDb.isSQL = True
+    secretDb.inScope = True
+    secretDb.storesPII = True
+    secretDb.maxClassification = Classification.TOP_SECRET
+
+    my_lambda = Lambda("AWS Lambda")
+    my_lambda.hasAccessControl = True
+    my_lambda.inBoundary = vpc
+    my_lambda.levels = [1, 2]
+
+    token_user_identity = Data(
+        "Token verifying user identity", classification=Classification.SECRET
+    )
+    db_to_secretDb = Dataflow(db, secretDb, "Database verify real user identity")
+    db_to_secretDb.protocol = "RDA-TCP"
+    db_to_secretDb.dstPort = 40234
+    db_to_secretDb.data = token_user_identity
+    db_to_secretDb.note = "Verifying that the user is who they say they are."
+    db_to_secretDb.maxClassification = Classification.SECRET
+
+    comments_in_text = Data(
+        "Comments in HTML or Markdown", classification=Classification.PUBLIC
+    )
+    user_to_web = Dataflow(user, web, "User enters comments (*)")
+    user_to_web.protocol = "HTTP"
+    user_to_web.dstPort = 80
+    user_to_web.data = comments_in_text
+    user_to_web.note = (
+        "This is a simple web app\nthat stores and retrieves user comments."
+    )
+
+    query_insert = Data(
+        "Insert query with comments", classification=Classification.PUBLIC
+    )
+    web_to_db = Dataflow(web, db, "Insert query with comments")
+    web_to_db.protocol = "MySQL"
+    web_to_db.dstPort = 3306
+    web_to_db.data = query_insert
+    web_to_db.note = "Web server inserts user comments\ninto it's SQL query and stores them in the DB."
+
+    comment_retrieved = Data(
+        "Web server retrieves comments from DB", classification=Classification.PUBLIC
+    )
+    db_to_web = Dataflow(db, web, "Retrieve comments")
+    db_to_web.protocol = "MySQL"
+    db_to_web.dstPort = 80
+    db_to_web.data = comment_retrieved
+    db_to_web.responseTo = web_to_db
+
+    comment_to_show = Data(
+        "Web server shows comments to the end user", classifcation=Classification.PUBLIC
+    )
+    web_to_user = Dataflow(web, user, "Show comments (*)")
+    web_to_user.protocol = "HTTP"
+    web_to_user.data = comment_to_show
+    web_to_user.responseTo = user_to_web
+
+    clear_op = Data(
+        "Serverless function clears DB", classification=Classification.PUBLIC
+    )
+    my_lambda_to_db = Dataflow(
+        my_lambda, db, "Serverless function periodically cleans DB"
+    )
+    my_lambda_to_db.protocol = "MySQL"
+    my_lambda_to_db.dstPort = 3306
+    my_lambda_to_db.data = clear_op
+
+    userIdToken = Data(
+        name="User ID Token",
+        description="Some unique token that represents the user real data in the secret database",
+        classification=Classification.TOP_SECRET,
+        traverses=[user_to_web, db_to_secretDb],
+        processedBy=[db, secretDb],
+    )
+
+    my_lambda_to_db = Dataflow(my_lambda, db, "Lambda periodically cleans DB")
+    my_lambda_to_db.protocol = "MySQL"
+    my_lambda_to_db.dstPort = 3306
+    my_lambda_to_db.data = "Lamda clears DB every 6 hours"
 
 if __name__ == "__main__":
     tm.process()


### PR DESCRIPTION
Using global attributes when building models makes it really hard to share assets between different models. Multiple models have to be stored in separate sources, cannot be processed together and unused assets are still drawn in diagrams.

This MR removes all usages of global/static attributes and requires to explicitly pass elements to a model. Note that only Dataflows have to be passed. See the new tests added for difference in usage.

Also note that previously, the sequence diagram relied on the order in which assets were defined (not dataflows). Now dataflows are used to order assets. It's still not consistent with being able to manually order dataflows but this can be improved in future MRs.