### PR TITLE
merge graph edges

### DIFF
--- a/tm.py
+++ b/tm.py
@@ -5,6 +5,7 @@ from pytm import TM, Server, Datastore, Dataflow, Boundary, Actor, Lambda
 tm = TM("my test tm")
 tm.description = "This is a sample threat model of a very simple system - a web-based comment system. The user enters comments and these are added to a database and displayed back to the user. The thought is that it is, though simple, a complete enough example to express meaningful threats."
 tm.isOrdered = True
+tm.mergeResponses = True
 
 internet = Boundary("Internet")
 server_db = Boundary("Server/DB")
@@ -47,10 +48,12 @@ db_to_web = Dataflow(db, web, "Retrieve comments")
 db_to_web.protocol = "MySQL"
 db_to_web.dstPort = 80
 db_to_web.data = 'Web server retrieves comments from DB'
+db_to_web.responseTo = web_to_db
 
 web_to_user = Dataflow(web, user, "Show comments (*)")
 web_to_user.protocol = "HTTP"
 web_to_user.data = 'Web server shows comments to the end user'
+web_to_user.responseTo = user_to_web
 
 my_lambda_to_db = Dataflow(my_lambda, db, "Lambda periodically cleans DB")
 my_lambda_to_db.protocol = "MySQL"


### PR DESCRIPTION
Allow to collapse a request and response dataflow into a single double-arrow edge. This greatly simplifies bigger DFDs and makes them more (actually) readable.

Added 3 new Dataflow attributes:
* isResponse - bool, when set and there's exactly one other dataflow for the same source and sink in reversed direction treat it as the request
* responseTo - point to another dataflow that this one is a response to
* response - point to another dataflow that's a response to this one

If only one of those attributes is set, others are filled in automatically, when possible.

When `TM.mergeResponses` is set, the resulting DFD would look like:
![dfd](https://user-images.githubusercontent.com/795177/75369392-a6e34280-58c3-11ea-977c-8a562e75dde9.png)


Possibly closes #53 