### PR TITLE
produce stable diagrams

### DIFF
--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -1,11 +1,13 @@
 import argparse
 import json
+import logging
+import random
 import uuid
 from collections import defaultdict
 from hashlib import sha224
 from os.path import dirname
-from re import match, sub
-from sys import argv, exit, stderr
+from re import match
+from sys import exit, stderr
 from textwrap import wrap
 from weakref import WeakKeyDictionary
 
@@ -16,6 +18,9 @@ from .template_engine import SuperFormatter
 ''' The base for this (descriptors instead of properties) has been shamelessly lifted from https://nbviewer.jupyter.org/urls/gist.github.com/ChrisBeaumont/5758381/raw/descriptor_writeup.ipynb
     By Chris Beaumont
 '''
+
+
+logger = logging.getLogger(__name__)
 
 
 class var(object):
@@ -91,19 +96,6 @@ def _setColor(element):
 
 def _setLabel(element):
     return "<br/>".join(wrap(element.name, 14))
-
-
-def _debug(_args, msg):
-    if _args.debug is True:
-        stderr.write("DEBUG: {}\n".format(msg))
-
-
-def _uniq_name(obj_name, obj_uuid):
-    ''' transform name and uuid into a unique string '''
-    hash_input = '{}{}'.format(obj_name, str(obj_uuid))
-    h = sha224(hash_input.encode('utf-8')).hexdigest()
-    hash_without_numbers = sub(r'[0-9]', '', h)
-    return hash_without_numbers
 
 
 def _sort(elements, addOrder=False):
@@ -217,6 +209,14 @@ class TM():
         self._sf = SuperFormatter()
         self._add_threats()
 
+    @classmethod
+    def reset(cls):
+        cls._BagOfFlows = []
+        cls._BagOfElements = []
+        cls._BagOfThreats = []
+        cls._BagOfFindings = []
+        cls._BagOfBoundaries = []
+
     def _init_threats(self):
         TM._BagOfThreats = []
         self._add_threats()
@@ -264,14 +264,14 @@ class TM():
         print("@startuml")
         for e in TM._BagOfElements:
             if isinstance(e, Actor):
-                print("actor {0} as \"{1}\"".format(_uniq_name(e.name, e.uuid), e.name))
+                print("actor {0} as \"{1}\"".format(e._uniq_name(), e.name))
             elif isinstance(e, Datastore):
-                print("database {0} as \"{1}\"".format(_uniq_name(e.name, e.uuid), e.name))
+                print("database {0} as \"{1}\"".format(e._uniq_name(), e.name))
             elif not isinstance(e, Dataflow) and not isinstance(e, Boundary):
-                print("entity {0} as \"{1}\"".format(_uniq_name(e.name, e.uuid), e.name))
+                print("entity {0} as \"{1}\"".format(e._uniq_name(), e.name))
 
         for e in TM._BagOfFlows:
-            print("{0} -> {1}: {2}".format(_uniq_name(e.source.name, e.source.uuid), _uniq_name(e.sink.name, e.sink.uuid), e.name))
+            print("{0} -> {1}: {2}".format(e.source._uniq_name(), e.sink._uniq_name(), e.name))
             if e.note != "":
                 print("note left\n{}\nend note".format(e.note))
         print("@enduml")
@@ -287,6 +287,9 @@ class TM():
     def process(self):
         self.check()
         result = get_args()
+        logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+        if result.debug:
+            logger.setLevel(logging.DEBUG)
         if result.seq is True:
             self.seq()
         if result.dfd is True:
@@ -328,16 +331,23 @@ class Element():
         for key, value in kwargs.items():
             setattr(self, key, value)
         self.name = name
-        self.uuid = uuid.uuid4()
+        self.uuid = uuid.UUID(int=random.getrandbits(128))
         self._is_drawn = False
         TM._BagOfElements.append(self)
 
     def __repr__(self):
-        return '<{0}.{1}({2}) at {3}>'.format(
-                self.__module__, type(self).__name__, self.name, hex(id(self)))
+        return "<{0}.{1}({2}) at {3}>".format(
+            self.__module__, type(self).__name__, self.name, hex(id(self))
+        )
 
     def __str__(self):
-        return '{0}({1})'.format(type(self).__name__, self.name)
+        return "{0}({1})".format(type(self).__name__, self.name)
+
+    def _uniq_name(self):
+        ''' transform name and uuid into a unique string '''
+        h = sha224(str(self.uuid).encode('utf-8')).hexdigest()
+        name = "".join(x for x in self.name if x.isalpha())
+        return "{0}_{1}_{2}".format(type(self).__name__.lower(), name, h[:10])
 
     def check(self):
         return True
@@ -348,12 +358,10 @@ class Element():
 
     def dfd(self, **kwargs):
         self._is_drawn = True
-        name = _uniq_name(self.name, self.uuid)
         label = _setLabel(self)
-        print("%s [\n\tshape = square;" % name)
+        print("%s [\n\tshape = square;" % self._uniq_name())
         print('\tlabel = <<table border="0" cellborder="0" cellpadding="2"><tr><td><b>{0}</b></td></tr></table>>;'.format(label))
         print("]")
-
 
 class Lambda(Element):
     onAWS = varBool(True)
@@ -375,11 +383,10 @@ class Lambda(Element):
 
     def dfd(self, **kwargs):
         self._is_drawn = True
-        name = _uniq_name(self.name, self.uuid)
         color = _setColor(self)
         pngpath = dirname(__file__) + "/images/lambda.png"
         label = _setLabel(self)
-        print('{0} [\n\tshape = none\n\tfixedsize=shape\n\timage="{2}"\n\timagescale=true\n\tcolor = {1}'.format(name, color, pngpath))
+        print('{0} [\n\tshape = none\n\tfixedsize=shape\n\timage="{2}"\n\timagescale=true\n\tcolor = {1}'.format(self._uniq_name(), color, pngpath))
         print('\tlabel = <<table border="0" cellborder="0" cellpadding="2"><tr><td><b>{}</b></td></tr></table>>;'.format(label))
         print("]")
 
@@ -423,10 +430,9 @@ class Server(Element):
 
     def dfd(self, **kwargs):
         self._is_drawn = True
-        name = _uniq_name(self.name, self.uuid)
         color = _setColor(self)
         label = _setLabel(self)
-        print("{0} [\n\tshape = circle\n\tcolor = {1}".format(name, color))
+        print("{0} [\n\tshape = circle\n\tcolor = {1}".format(self._uniq_name(), color))
         print('\tlabel = <<table border="0" cellborder="0" cellpadding="2"><tr><td><b>{}</b></td></tr></table>>;'.format(label))
         print("]")
 
@@ -471,10 +477,9 @@ class Datastore(Element):
 
     def dfd(self, **kwargs):
         self._is_drawn = True
-        name = _uniq_name(self.name, self.uuid)
         color = _setColor(self)
         label = _setLabel(self)
-        print("{0} [\n\tshape = none;\n\tcolor = {1};".format(name, color))
+        print("{0} [\n\tshape = none;\n\tcolor = {1};".format(self._uniq_name(), color))
         print('\tlabel = <<table sides="TB" cellborder="0" cellpadding="2"><tr><td><font color="{1}"><b>{0}</b></font></td></tr></table>>;'.format(label, color))
         print("]")
 
@@ -487,9 +492,8 @@ class Actor(Element):
 
     def dfd(self, **kwargs):
         self._is_drawn = True
-        name = _uniq_name(self.name, self.uuid)
         label = _setLabel(self)
-        print("%s [\n\tshape = square;" % name)
+        print("%s [\n\tshape = square;" % self._uniq_name())
         print('\tlabel = <<table border="0" cellborder="0" cellpadding="2"><tr><td><b>{0}</b></td></tr></table>>;'.format(label))
         print("]")
 
@@ -539,10 +543,9 @@ class Process(Element):
 
     def dfd(self, **kwargs):
         self._is_drawn = True
-        name = _uniq_name(self.name, self.uuid)
         color = _setColor(self)
         label = _setLabel(self)
-        print("{0} [\n\tshape = circle;\n\tcolor = {1};\n".format(name, color))
+        print("{0} [\n\tshape = circle;\n\tcolor = {1};\n".format(self._uniq_name(), color))
         print('\tlabel = <<table border="0" cellborder="0" cellpadding="2"><tr><td><font color="{1}"><b>{0}</b></font></td></tr></table>>;'.format(label, color))
         print("]")
 
@@ -553,10 +556,9 @@ class SetOfProcesses(Process):
 
     def dfd(self, **kwargs):
         self._is_drawn = True
-        name = _uniq_name(self.name, self.uuid)
         color = _setColor(self)
         label = _setLabel(self)
-        print("{0} [\n\tshape = doublecircle;\n\tcolor = {1};\n".format(name, color))
+        print("{0} [\n\tshape = doublecircle;\n\tcolor = {1};\n".format(self._uniq_name(), color))
         print('\tlabel = <<table border="0" cellborder="0" cellpadding="2"><tr><td><font color="{1}"><b>{0}</b></font></td></tr></table>>;'.format(label, color))
         print("]")
 
@@ -611,8 +613,8 @@ class Dataflow(Element):
                 resp_label = "({0}) {1}".format(self.response.order, resp_label)
             label += "<br/>" + resp_label
         print("\t{0} -> {1} [\n\t\tcolor = {2};\n\t\tdir = {3};\n".format(
-            _uniq_name(self.source.name, self.source.uuid),
-            _uniq_name(self.sink.name, self.sink.uuid),
+            self.source._uniq_name(),
+            self.sink._uniq_name(),
             color,
             direction,
         ))
@@ -630,16 +632,14 @@ class Boundary(Element):
         if self._is_drawn:
             return
 
-        result = get_args()
         self._is_drawn = True
-        _debug(result, "Now drawing boundary " + self.name)
-        name = _uniq_name(self.name, self.uuid)
+        logger.debug("Now drawing boundary " + self.name)
         label = self.name
-        print("subgraph cluster_{0} {{\n\tgraph [\n\t\tfontsize = 10;\n\t\tfontcolor = firebrick2;\n\t\tstyle = dashed;\n\t\tcolor = firebrick2;\n\t\tlabel = <<i>{1}</i>>;\n\t]\n".format(name, label))
+        print("subgraph cluster_{0} {{\n\tgraph [\n\t\tfontsize = 10;\n\t\tfontcolor = firebrick2;\n\t\tstyle = dashed;\n\t\tcolor = firebrick2;\n\t\tlabel = <<i>{1}</i>>;\n\t]\n".format(self._uniq_name(), label))
         for e in TM._BagOfElements:
             if e.inBoundary == self and not e._is_drawn:
                 # The content to draw can include Boundary objects
-                _debug(result, "Now drawing content {}".format(e.name))
+                logger.debug("Now drawing content {}".format(e.name))
                 e.dfd()
         print("\n}\n")
 

--- a/tests/dfd.dot
+++ b/tests/dfd.dot
@@ -1,0 +1,82 @@
+digraph tm {
+	graph [
+	fontname = Arial;
+	fontsize = 14;
+	]
+	node [
+	fontname = Arial;
+	fontsize = 14;
+	rankdir = lr;
+	]
+	edge [
+	shape = none;
+	fontname = Arial;
+	fontsize = 12;
+	]
+	labelloc = "t";
+	fontsize = 20;
+	nodesep = 1;
+
+subgraph cluster_boundary_Internet_acf3059e70 {
+	graph [
+		fontsize = 10;
+		fontcolor = firebrick2;
+		style = dashed;
+		color = firebrick2;
+		label = <<i>Internet</i>>;
+	]
+
+actor_User_579e9aae81 [
+	shape = square;
+	label = <<table border="0" cellborder="0" cellpadding="2"><tr><td><b>User</b></td></tr></table>>;
+]
+
+}
+
+subgraph cluster_boundary_ServerDB_88f2d9c06f {
+	graph [
+		fontsize = 10;
+		fontcolor = firebrick2;
+		style = dashed;
+		color = firebrick2;
+		label = <<i>Server/DB</i>>;
+	]
+
+datastore_SQLDatabase_d2006ce1bb [
+	shape = none;
+	color = black;
+	label = <<table sides="TB" cellborder="0" cellpadding="2"><tr><td><font color="black"><b>SQL Database</b></font></td></tr></table>>;
+]
+
+}
+
+server_WebServer_f2eb7a3ff7 [
+	shape = circle
+	color = black
+	label = <<table border="0" cellborder="0" cellpadding="2"><tr><td><b>Web Server</b></td></tr></table>>;
+]
+	actor_User_579e9aae81 -> server_WebServer_f2eb7a3ff7 [
+		color = black;
+		dir = forward;
+
+		label = <<table border="0" cellborder="0" cellpadding="2"><tr><td><font color="black"><b>User enters<br/>comments (*)</b></font></td></tr></table>>;
+	]
+	server_WebServer_f2eb7a3ff7 -> datastore_SQLDatabase_d2006ce1bb [
+		color = black;
+		dir = forward;
+
+		label = <<table border="0" cellborder="0" cellpadding="2"><tr><td><font color="black"><b>Insert query<br/>with comments</b></font></td></tr></table>>;
+	]
+	datastore_SQLDatabase_d2006ce1bb -> server_WebServer_f2eb7a3ff7 [
+		color = black;
+		dir = forward;
+
+		label = <<table border="0" cellborder="0" cellpadding="2"><tr><td><font color="black"><b>Retrieve<br/>comments</b></font></td></tr></table>>;
+	]
+	server_WebServer_f2eb7a3ff7 -> actor_User_579e9aae81 [
+		color = black;
+		dir = forward;
+
+		label = <<table border="0" cellborder="0" cellpadding="2"><tr><td><font color="black"><b>Show comments<br/>(*)</b></font></td></tr></table>>;
+	]
+}

--- a/tests/seq.plantuml
+++ b/tests/seq.plantuml
@@ -1,0 +1,15 @@
+@startuml
+actor actor_User_579e9aae81 as "User"
+entity server_WebServer_f2eb7a3ff7 as "Web Server"
+database datastore_SQLDatabase_d2006ce1bb as "SQL Database"
+actor_User_579e9aae81 -> server_WebServer_f2eb7a3ff7: User enters comments (*)
+note left
+bbb
+end note
+server_WebServer_f2eb7a3ff7 -> datastore_SQLDatabase_d2006ce1bb: Insert query with comments
+note left
+ccc
+end note
+datastore_SQLDatabase_d2006ce1bb -> server_WebServer_f2eb7a3ff7: Retrieve comments
+server_WebServer_f2eb7a3ff7 -> actor_User_579e9aae81: Show comments (*)
+@enduml

--- a/tests/test_private_func.py
+++ b/tests/test_private_func.py
@@ -1,19 +1,23 @@
 import sys
 sys.path.append("..")
 import unittest
+import random
 
-from pytm.pytm import _uniq_name, Actor, Boundary, Dataflow, Datastore, Server, TM
+from pytm.pytm import Actor, Boundary, Dataflow, Datastore, Server, TM
 
 
 class TestUniqueNames(unittest.TestCase):
     def test_duplicate_boundary_names_have_different_unique_names(self):
+        random.seed(0)
         object_1 = Boundary("foo")
         object_2 = Boundary("foo")
 
-        object_1_uniq_name = _uniq_name(object_1.name, object_1.uuid)
-        object_2_uniq_name = _uniq_name(object_2.name, object_2.uuid)
+        object_1_uniq_name = object_1._uniq_name()
+        object_2_uniq_name = object_2._uniq_name()
 
         self.assertNotEqual(object_1_uniq_name, object_2_uniq_name)
+        self.assertEqual(object_1_uniq_name, "boundary_foo_acf3059e70")
+        self.assertEqual(object_2_uniq_name, "boundary_foo_88f2d9c06f")
 
 
 class TestAttributes(unittest.TestCase):

--- a/tm.py
+++ b/tm.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 
-from pytm import TM, Server, Datastore, Dataflow, Boundary, Actor, Lambda
+import random
+
+from pytm import TM, Actor, Boundary, Dataflow, Datastore, Lambda, Server
+
+# make sure generated diagrams do not change, makes sense if they're commited
+random.seed(0)
 
 tm = TM("my test tm")
 tm.description = "This is a sample threat model of a very simple system - a web-based comment system. The user enters comments and these are added to a database and displayed back to the user. The thought is that it is, though simple, a complete enough example to express meaningful threats."
@@ -60,4 +65,6 @@ my_lambda_to_db.protocol = "MySQL"
 my_lambda_to_db.dstPort = 3306
 my_lambda_to_db.data = "Lamda clears DB every 6 hours"
 
-tm.process()
+
+if __name__ == "__main__":
+    tm.process()


### PR DESCRIPTION
The sequence image file generated using plantuml is changing on every run. If this file is commited to a repository together with the model it's slightly annoying to see it in diffs of every commit, although the model did not change. This PR switches from using UUIDv4 to a generic UUID that would respect setting a seed.

Added unit tests for generated dfd and seq. Verified additionally using:
```bash
$ make report
mkdir -p tm
./tm.py --dfd | dot -Tpng -o tm/dfd.png
./tm.py --seq | java -Djava.awt.headless=true -jar ./plantuml.jar -tpng -pipe > tm/seq.png
./tm.py --report docs/template.md | pandoc -f markdown -t html > tm/report.html
$ cp tm/seq.png tm/seq2.png
$ make report
mkdir -p tm
./tm.py --dfd | dot -Tpng -o tm/dfd.png
./tm.py --seq | java -Djava.awt.headless=true -jar ./plantuml.jar -tpng -pipe > tm/seq.png
./tm.py --report docs/template.md | pandoc -f markdown -t html > tm/report.html
$ md5sum tm/seq.png tm/seq2.png
6c7381e51004ec38bbe4a7522900f37b  tm/seq.png
6c7381e51004ec38bbe4a7522900f37b  tm/seq2.png
```