### PR TITLE
render diagrams using templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,5 +121,6 @@ tm_example.dot
 .idea
 *.iml
 
+#Others
 plantuml.jar
 tm/

--- a/tests/dfd.dot
+++ b/tests/dfd.dot
@@ -1,91 +1,120 @@
 digraph tm {
-	graph [
-	fontname = Arial;
-	fontsize = 14;
-	]
-	node [
-	fontname = Arial;
-	fontsize = 14;
-	rankdir = lr;
-	]
-	edge [
-	shape = none;
-	arrowtail = onormal;
-	fontname = Arial;
-	fontsize = 12;
-	]
-	labelloc = "t";
-	fontsize = 20;
-	nodesep = 1;
+    graph [
+        fontname = Arial;
+        fontsize = 14;
+    ]
+    node [
+        fontname = Arial;
+        fontsize = 14;
+        rankdir = lr;
+    ]
+    edge [
+        shape = none;
+        arrowtail = onormal;
+        fontname = Arial;
+        fontsize = 12;
+    ]
+    labelloc = "t";
+    fontsize = 20;
+    nodesep = 1;
 
-subgraph cluster_boundary_Internet_acf3059e70 {
-	graph [
-		fontsize = 10;
-		fontcolor = firebrick2;
-		style = dashed;
-		color = firebrick2;
-		label = <<i>Internet</i>>;
-	]
+    subgraph cluster_boundary_Internet_acf3059e70 {
+        graph [
+            fontsize = 10;
+            fontcolor = firebrick2;
+            style = dashed;
+            color = firebrick2;
+            label = <<i>Internet</i>>;
+        ]
 
-actor_User_579e9aae81 [
-	shape = square;
-	color = black;
-	fontcolor = black;
-	label = <<table border="0" cellborder="0" cellpadding="2"><tr><td><b>User</b></td></tr></table>>;
-]
+        actor_User_579e9aae81 [
+            shape = square;
+            color = black;
+            fontcolor = black;
+            label = <
+                <table border="0" cellborder="0" cellpadding="2">
+                    <tr><td><b>User</b></td></tr>
+                </table>
+            >;
+        ]
 
-}
+    }
 
-subgraph cluster_boundary_ServerDB_88f2d9c06f {
-	graph [
-		fontsize = 10;
-		fontcolor = firebrick2;
-		style = dashed;
-		color = firebrick2;
-		label = <<i>Server/DB</i>>;
-	]
+    subgraph cluster_boundary_ServerDB_88f2d9c06f {
+        graph [
+            fontsize = 10;
+            fontcolor = firebrick2;
+            style = dashed;
+            color = firebrick2;
+            label = <<i>Server/DB</i>>;
+        ]
 
-datastore_SQLDatabase_d2006ce1bb [
-	shape = none;
-	color = black;
-	fontcolor = black;
-	label = <<table sides="TB" cellborder="0" cellpadding="2"><tr><td><b>SQL Database</b></td></tr></table>>;
-]
+        datastore_SQLDatabase_d2006ce1bb [
+            shape = none;
+            color = black;
+            fontcolor = black;
+            label = <
+                <table sides="TB" cellborder="0" cellpadding="2">
+                    <tr><td><b>SQL Database</b></td></tr>
+                </table>
+            >;
+        ]
 
-}
+    }
 
-server_WebServer_f2eb7a3ff7 [
-	shape = circle
-	color = black;
-	fontcolor = black;
-	label = <<table border="0" cellborder="0" cellpadding="2"><tr><td><b>Web Server</b></td></tr></table>>;
-]
-	actor_User_579e9aae81 -> server_WebServer_f2eb7a3ff7 [
-		color = black;
-		fontcolor = black;
-		dir = forward;
+    server_WebServer_f2eb7a3ff7 [
+        shape = circle;
+        color = black;
+        fontcolor = black;
+        label = <
+            <table border="0" cellborder="0" cellpadding="2">
+                <tr><td><b>Web Server</b></td></tr>
+            </table>
+        >;
+    ]
 
-		label = <<table border="0" cellborder="0" cellpadding="2"><tr><td><b>User enters<br/>comments (*)</b></td></tr></table>>;
-	]
-	server_WebServer_f2eb7a3ff7 -> datastore_SQLDatabase_d2006ce1bb [
-		color = black;
-		fontcolor = black;
-		dir = forward;
+    actor_User_579e9aae81 -> server_WebServer_f2eb7a3ff7 [
+        color = black;
+        fontcolor = black;
+        dir = forward;
+        label = <
+            <table border="0" cellborder="0" cellpadding="2">
+                <tr><td><font color="black"><b>User enters<br/>comments (*)</b></font></td></tr>
+            </table>
+        >;
+    ]
 
-		label = <<table border="0" cellborder="0" cellpadding="2"><tr><td><b>Insert query<br/>with comments</b></td></tr></table>>;
-	]
-	datastore_SQLDatabase_d2006ce1bb -> server_WebServer_f2eb7a3ff7 [
-		color = black;
-		fontcolor = black;
-		dir = forward;
+    server_WebServer_f2eb7a3ff7 -> datastore_SQLDatabase_d2006ce1bb [
+        color = black;
+        fontcolor = black;
+        dir = forward;
+        label = <
+            <table border="0" cellborder="0" cellpadding="2">
+                <tr><td><font color="black"><b>Insert query with<br/>comments</b></font></td></tr>
+            </table>
+        >;
+    ]
 
-		label = <<table border="0" cellborder="0" cellpadding="2"><tr><td><b>Retrieve<br/>comments</b></td></tr></table>>;
-	]
-	server_WebServer_f2eb7a3ff7 -> actor_User_579e9aae81 [
-		color = black;
-		fontcolor = black;
-		dir = forward;
+    datastore_SQLDatabase_d2006ce1bb -> server_WebServer_f2eb7a3ff7 [
+        color = black;
+        fontcolor = black;
+        dir = forward;
+        label = <
+            <table border="0" cellborder="0" cellpadding="2">
+                <tr><td><font color="black"><b>Retrieve comments</b></font></td></tr>
+            </table>
+        >;
+    ]
 
-		label = <<table border="0" cellborder="0" cellpadding="2"><tr><td><b>Show comments<br/>(*)</b></td></tr></table>>;
-	]
+    server_WebServer_f2eb7a3ff7 -> actor_User_579e9aae81 [
+        color = black;
+        fontcolor = black;
+        dir = forward;
+        label = <
+            <table border="0" cellborder="0" cellpadding="2">
+                <tr><td><font color="black"><b>Show comments (*)</b></font></td></tr>
+            </table>
+        >;
+    ]
+
 }

--- a/tests/seq.plantuml
+++ b/tests/seq.plantuml
@@ -2,6 +2,7 @@
 actor actor_User_579e9aae81 as "User"
 entity server_WebServer_f2eb7a3ff7 as "Web Server"
 database datastore_SQLDatabase_d2006ce1bb as "SQL Database"
+
 actor_User_579e9aae81 -> server_WebServer_f2eb7a3ff7: User enters comments (*)
 note left
 bbb

--- a/tests/seq_unused.plantuml
+++ b/tests/seq_unused.plantuml
@@ -2,6 +2,7 @@
 actor actor_User_579e9aae81 as "User"
 database datastore_SQLDatabase_d2006ce1bb as "SQL Database"
 entity server_WebServer_f2eb7a3ff7 as "Web Server"
+
 actor_User_579e9aae81 -> server_WebServer_f2eb7a3ff7: User enters comments (*)
 note left
 bbb

--- a/tests/test_pytmfunc.py
+++ b/tests/test_pytmfunc.py
@@ -2,11 +2,7 @@ import json
 import os
 import random
 import re
-import sys
 import unittest
-from contextlib import contextmanager
-from io import StringIO
-from os.path import dirname
 
 from pytm import (
     TM,
@@ -22,19 +18,12 @@ from pytm import (
     Threat,
 )
 
-with open(os.path.abspath(os.path.join(dirname(__file__), '..')) + "/pytm/threatlib/threats.json", "r") as threat_file:
+with open(
+    os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    + "/pytm/threatlib/threats.json",
+    "r",
+) as threat_file:
     threats = {t["SID"]: Threat(**t) for t in json.load(threat_file)}
-
-
-@contextmanager
-def captured_output():
-    new_out, new_err = StringIO(), StringIO()
-    old_out, old_err = sys.stdout, sys.stderr
-    try:
-        sys.stdout, sys.stderr = new_out, new_err
-        yield sys.stdout, sys.stderr
-    finally:
-        sys.stdout, sys.stderr = old_out, old_err
 
 
 class TestTM(unittest.TestCase):
@@ -59,10 +48,8 @@ class TestTM(unittest.TestCase):
         Dataflow(web, user, "Show comments (*)")
 
         tm.check()
-        with captured_output() as (out, err):
-            tm.seq()
+        output = tm.seq()
 
-        output = out.getvalue().strip()
         self.maxDiff = None
         self.assertEqual(output, expected)
 
@@ -87,10 +74,8 @@ class TestTM(unittest.TestCase):
         Dataflow(web, user, "Show comments (*)")
 
         tm.check()
-        with captured_output() as (out, err):
-            tm.seq()
+        output = tm.seq()
 
-        output = out.getvalue().strip()
         self.maxDiff = None
         self.assertEqual(output, expected)
 
@@ -115,10 +100,8 @@ class TestTM(unittest.TestCase):
         Dataflow(web, user, "Show comments (*)")
 
         tm.check()
-        with captured_output() as (out, err):
-            tm.dfd()
+        output = tm.dfd()
 
-        output = out.getvalue().strip()
         self.maxDiff = None
         self.assertEqual(output, expected)
 
@@ -145,10 +128,8 @@ class TestTM(unittest.TestCase):
         Dataflow(web, user, "Show comments (*)")
 
         tm.check()
-        with captured_output() as (out, err):
-            tm.dfd()
+        output = tm.dfd()
 
-        output = out.getvalue().strip()
         self.maxDiff = None
         self.assertEqual(output, expected)
 
@@ -170,7 +151,11 @@ class TestTM(unittest.TestCase):
         Dataflow(db, web, "Retrieve comments")
         Dataflow(web, user, "Show comments (*)")
 
-        e = re.escape("Duplicate Dataflow found between Actor(User) and Server(Web Server): Dataflow(User enters comments (*)) is same as Dataflow(User views comments)")
+        e = re.escape(
+            "Duplicate Dataflow found between Actor(User) "
+            "and Server(Web Server): Dataflow(User enters comments (*)) "
+            "is same as Dataflow(User views comments)"
+        )
         with self.assertRaisesRegex(ValueError, e):
             tm.check()
 
@@ -197,7 +182,10 @@ class TestTM(unittest.TestCase):
         tm.resolve()
 
         self.maxDiff = None
-        self.assertListEqual([f.id for f in tm.findings], ['Server', 'Datastore', 'Dataflow', 'Dataflow', 'Dataflow', 'Dataflow'])
+        self.assertListEqual(
+            [f.id for f in tm.findings],
+            ["Server", "Datastore", "Dataflow", "Dataflow", "Dataflow", "Dataflow"],
+        )
         self.assertListEqual([f.id for f in user.findings], [])
         self.assertListEqual([f.id for f in web.findings], ["Server"])
         self.assertListEqual([f.id for f in db.findings], ["Datastore"])


### PR DESCRIPTION
Make it easier to customize diagrams by overloading classes:
* make `_setColor()` and `_setLabel()` methods of the Element class so it's easier to customize diagrams by overloading classes,
* use `format()` as primitive templates when rendering dfd and seq diagrams
* return strings instead of printing them directly