### PR TITLE
allow advanced templates in repeat blocks

### DIFF
--- a/pytm/template_engine.py
+++ b/pytm/template_engine.py
@@ -11,7 +11,7 @@ class SuperFormatter(string.Formatter):
             template = spec.partition(':')[-1]
             if type(value) is dict:
                 value = value.items()
-            return ''.join([template.format(item=item) for item in value])
+            return ''.join([self.format(template, item=item) for item in value])
         elif spec == 'call':
             return value()
         elif spec.startswith('if'):


### PR DESCRIPTION
Allows to call methods on items in repeat blocks (notice `item.target.display_name:call`):
```
{findings:repeat:|{{item.target.display_name:call}}|{{item.id}}|{{item.description}}|{{item.severity}}|{{item.details}}|{{item.mitigations}}|{{item.example}}|{{item.references}}
}
```
We could use the property decorator but there's no reason why the slightly more advanced template format shouldn't be supported in the repeat block.