### PR TITLE
ignore unused elements

### DIFF
--- a/tests/seq_unused.plantuml
+++ b/tests/seq_unused.plantuml
@@ -1,0 +1,15 @@
+@startuml
+actor actor_User_579e9aae81 as "User"
+database datastore_SQLDatabase_d2006ce1bb as "SQL Database"
+entity server_WebServer_f2eb7a3ff7 as "Web Server"
+actor_User_579e9aae81 -> server_WebServer_f2eb7a3ff7: User enters comments (*)
+note left
+bbb
+end note
+server_WebServer_f2eb7a3ff7 -> datastore_SQLDatabase_d2006ce1bb: Insert query with comments
+note left
+ccc
+end note
+datastore_SQLDatabase_d2006ce1bb -> server_WebServer_f2eb7a3ff7: Retrieve comments
+server_WebServer_f2eb7a3ff7 -> actor_User_579e9aae81: Show comments (*)
+@enduml

--- a/tests/test_pytmfunc.py
+++ b/tests/test_pytmfunc.py
@@ -49,6 +49,35 @@ class TestTM(unittest.TestCase):
         Dataflow(db, web, "Retrieve comments")
         Dataflow(web, user, "Show comments (*)")
 
+        tm.check()
+        with captured_output() as (out, err):
+            tm.seq()
+
+        output = out.getvalue().strip()
+        self.maxDiff = None
+        self.assertEqual(output, expected)
+
+    def test_seq_unused(self):
+        random.seed(0)
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        with open(os.path.join(dir_path, 'seq_unused.plantuml')) as x:
+            expected = x.read().strip()
+
+        TM.reset()
+        tm = TM("my test tm", description="aaa", ignoreUnused=True)
+        internet = Boundary("Internet")
+        server_db = Boundary("Server/DB")
+        user = Actor("User", inBoundary=internet)
+        web = Server("Web Server")
+        db = Datastore("SQL Database", inBoundary=server_db)
+        Lambda("Unused Lambda")
+
+        Dataflow(user, web, "User enters comments (*)", note="bbb")
+        Dataflow(web, db, "Insert query with comments", note="ccc")
+        Dataflow(db, web, "Retrieve comments")
+        Dataflow(web, user, "Show comments (*)")
+
+        tm.check()
         with captured_output() as (out, err):
             tm.seq()
 
@@ -76,6 +105,7 @@ class TestTM(unittest.TestCase):
         Dataflow(db, web, "Retrieve comments")
         Dataflow(web, user, "Show comments (*)")
 
+        tm.check()
         with captured_output() as (out, err):
             tm.dfd()
 


### PR DESCRIPTION
If a new TM class attribute `ignoreUnused` is True, ignore all elements and boundaries not used in any Dataflow. This is needed when building multiple models using assets imported from a single python module, where some assets are not used in every model.

This will be superseded by #75