### PR TITLE
support running in a docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,5 @@ tm_example.dot
 .idea
 *.iml
 
+plantuml.jar
+tm/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.8.2-alpine3.11
+
+WORKDIR /usr/src/app
+ENTRYPOINT ["sh"]
+
+ENV PLANTUML_VER 1.2020.2
+ENV PLANTUML_PATH /usr/local/lib/plantuml.jar
+ENV PANDOC_VER 2.9.2
+
+RUN apk add --no-cache graphviz openjdk11-jre fontconfig make curl ttf-liberation ttf-linux-libertine ttf-dejavu \
+    && curl -LO https://netix.dl.sourceforge.net/project/plantuml/$PLANTUML_VER/plantuml.$PLANTUML_VER.jar \
+    && mv plantuml.$PLANTUML_VER.jar $PLANTUML_PATH \
+    && curl -LO https://github.com/jgm/pandoc/releases/download/$PANDOC_VER/pandoc-$PANDOC_VER-linux-amd64.tar.gz \
+    && tar xvzf pandoc-$PANDOC_VER-linux-amd64.tar.gz --strip-components 1 -C /usr/local/
+
+ENV _JAVA_OPTIONS -Duser.home=/tmp -Dawt.useSystemAAFontSettings=gasp
+RUN printf '@startuml\n@enduml' | java -Djava.awt.headless=true -jar $PLANTUML_PATH -tpng -pipe >/dev/null
+
+COPY pytm ./pytm
+COPY docs ./docs
+COPY *.py Makefile ./

--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,53 @@
 UNAME_S := $(shell uname -s)
-    ifeq ($(UNAME_S),Linux)
-        SED = /usr/bin/sed
-    endif
-    ifeq ($(UNAME_S),Darwin)
-        SED = /usr/local/bin/gsed
-    endif
+ifeq ($(UNAME_S),Linux)
+    SED = sed
+endif
+ifeq ($(UNAME_S),Darwin)
+    SED = gsed
+endif
 
 PREV:=$(shell grep version= setup.py | $(SED) -E -e "s/\s*version='([0-9]*.[0-9]*)',/\1/")
 NEXT:=$(shell echo $(PREV)+0.1 | /usr/bin/bc | $(SED) -E -e "s/^\./0\./")
 #DEPLOYURL=--repository-url https://test.pypi.org/legacy/
 DEPLOYURL=
 
-all: clean build tm report
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+CWD := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
+DOCKER_IMG := pytm
+
+ifeq ($(USE_DOCKER),true)
+	SHELL=docker
+	.SHELLFLAGS=run -u $$(id -u) -v $(CWD):/usr/src/app --rm $(DOCKER_IMG):latest -c
+endif
+ifndef PLANTUML_PATH
+	export PLANTUML_PATH = ./plantuml.jar
+endif
+
+models := tm.py
+libs := $(wildcard pytm/*.py) $(wildcard pytm/threatlib/*.json) $(wildcard pytm/images/*)
+all: clean build
+all: $(models:.py=/report.html) $(models:.py=/dfd.png) $(models:.py=/seq.png)
 
 clean:
-	rm -rf dist/* build/*
+	rm -rf dist/* build/* $(models:.py=/*)
 
 tm:
 	mkdir -p tm
 
-dfd:
-	./tm.py --dfd | dot -Tpng -o tm/dfd.png
+%/dfd.png: %.py tm $(libs)
+	./$< --dfd | dot -Tpng -o $@
 
-seq:
-	./tm.py --seq | java -Djava.awt.headless=true -jar ./plantuml.jar -tpng -pipe > tm/seq.png
+%/seq.png: %.py tm $(libs)
+	./$< --seq | java -Djava.awt.headless=true -jar $$PLANTUML_PATH -tpng -pipe > $@
 
-report: tm dfd seq
-	./tm.py --report docs/template.md | pandoc -f markdown -t html > tm/report.html
+%/report.html: %.py tm $(libs) docs/template.md docs/Stylesheet.css
+	./$< --report docs/template.md | pandoc -f markdown -t html > $@
+
+dfd: $(models:.py=/dfd.png)
+
+seq: $(models:.py=/seq.png)
+
+report: $(models:.py=/report.html) seq dfd
 
 build: setup.py
 	#cat setup.py | sed -e "s/'$(PREV)'/'$(NEXT)'/" > newver.py
@@ -35,4 +56,10 @@ build: setup.py
 	python3 setup.py sdist bdist_wheel
 	twine upload $(DEPLOYURL) dist/*
 
-.PHONY: tm
+.PHONY: describe
+describe:
+	for i in TM Element Server ExternalEntity Datastore Actor Process SetOfProcesses Dataflow Boundary Lambda Finding; do ./tm.py --describe $$i; done
+
+.PHONY: image
+image:
+	docker build -t $(DOCKER_IMG) .

--- a/docs/template.md
+++ b/docs/template.md
@@ -29,20 +29,20 @@ Name|From|To |Data|Protocol|Port
 
 |{findings:repeat:
 <details>
-  <summary>   {{item.id}}   --   {{item.description}}</summary> 
+  <summary>   {{item.id}}   --   {{item.description}}</summary>
   <h6> Targeted Element </h6>
   <p> {{item.target}} </p>
   <h6> Severity </h6>
   <p>{{item.severity}}</p>
   <h6>Example Instances</h6>
-  <p>{{item.example}}</p>   
+  <p>{{item.example}}</p>
   <h6>Mitigations</h6>
   <p>{{item.mitigations}}</p>
   <h6>References</h6>
-  <p>{{item.references}}</p> 
+  <p>{{item.references}}</p>
   &nbsp;
   &nbsp;
-  &emsp;      
+  &emsp;
 </details>
 }|
 


### PR DESCRIPTION
New make targets and vars:
* `make image` builds a `pytm` Docker image
* `make tm/report.html` or any other file (dfd.png, seq.png) to build single files, useful if having multiple models but working only on one
* `make report USE_DOCKER=true` runs everything in a Docker container

Targets correctly recognize file timestamps so only results for updated files are being built.

> NOTE: I can't test this on OSX as I don't have a mac