### PR TITLE
describe class attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ build: setup.py
 
 .PHONY: describe
 describe:
-	for i in TM Element Server ExternalEntity Datastore Actor Process SetOfProcesses Dataflow Boundary Lambda Finding; do ./tm.py --describe $$i; done
+	./tm.py --describe "TM Element Boundary ExternalEntity Actor Lambda Server Process SetOfProcesses Datastore Dataflow"
 
 .PHONY: image
 image:

--- a/README.md
+++ b/README.md
@@ -36,21 +36,19 @@ The available properties of an element can be listed by using `--describe` follo
 ```text
 
 (pytm) ➜  pytm git:(master) ✗ ./tm.py --describe Element
-Element
-	OS
-	check
-	definesConnectionTimeout
-	description
-	dfd
-	handlesResources
-	implementsAuthenticationScheme
-	implementsNonce
-	inBoundary
-	inScope
-	isAdmin
-	isHardened
-	name
-	onAWS
+Element class attributes:
+  OS
+  definesConnectionTimeout        default: False
+  description
+  handlesResources                default: False
+  implementsAuthenticationScheme  default: False
+  implementsNonce                 default: False
+  inBoundary
+  inScope                         Is the element in scope of the threat model, default: True
+  isAdmin                         default: False
+  isHardened                      default: False
+  name                            required
+  onAWS                           default: False
 
 ```
 


### PR DESCRIPTION
Greatly improve the `--describe` command by adding class attributes docs and marking which ones are required. Also print default values.

> **Note**: in this MR I do not try to document all attributes but only the most obvious ones

Here's the current (truncated) output of the `make describe` command:
```
TM class attributes:
  description     Model description, required
  isOrdered       Automatically order all Dataflows, default: False
  mergeResponses  Merge response edges in DFDs, default: False
  name            Model name, required
  threatsFile     JSON file with custom threats, default: /home/jwas/src/pytm/pytm/threatlib/threats.json

Element class attributes:
  OS
  definesConnectionTimeout        default: False
  description
  handlesResources                default: False
  implementsAuthenticationScheme  default: False
  implementsNonce                 default: False
  inBoundary
  inScope                         Is the element in scope of the threat model, default: True
  isAdmin                         default: False
  isHardened                      default: False
  name                            required
  onAWS                           default: False

...
```

Possibly closes #78 