### PR TITLE
use numbered dataflow labels on seq diagram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## New features
 
+- Use numbered dataflow labels in sequence diagram [#94](https://github.com/izar/pytm/pull/94)
 - Move authenticateDestination to base Element [#88](https://github.com/izar/pytm/pull/88)
 - Assign inputs and outputs to all elements [#89](https://github.com/izar/pytm/pull/89)
 - Allow detecting and/or hiding duplicate dataflows by setting `TM.onDuplicates` [#100](https://github.com/izar/pytm/pull/100)

--- a/tests/seq.plantuml
+++ b/tests/seq.plantuml
@@ -3,14 +3,14 @@ actor actor_User_579e9aae81 as "User"
 entity server_WebServer_f2eb7a3ff7 as "Web Server"
 database datastore_SQLDatabase_d2006ce1bb as "SQL Database"
 
-actor_User_579e9aae81 -> server_WebServer_f2eb7a3ff7: User enters comments (*)
+actor_User_579e9aae81 -> server_WebServer_f2eb7a3ff7: (1) User enters comments (*)
 note left
 bbb
 end note
-server_WebServer_f2eb7a3ff7 -> datastore_SQLDatabase_d2006ce1bb: Insert query with comments
+server_WebServer_f2eb7a3ff7 -> datastore_SQLDatabase_d2006ce1bb: (2) Insert query with comments
 note left
 ccc
 end note
-datastore_SQLDatabase_d2006ce1bb -> server_WebServer_f2eb7a3ff7: Retrieve comments
-server_WebServer_f2eb7a3ff7 -> actor_User_579e9aae81: Show comments (*)
+datastore_SQLDatabase_d2006ce1bb -> server_WebServer_f2eb7a3ff7: (3) Retrieve comments
+server_WebServer_f2eb7a3ff7 -> actor_User_579e9aae81: (4) Show comments (*)
 @enduml

--- a/tests/test_pytmfunc.py
+++ b/tests/test_pytmfunc.py
@@ -36,6 +36,7 @@ class TestTM(unittest.TestCase):
 
         TM.reset()
         tm = TM("my test tm", description="aaa")
+        tm.isOrdered = True
         internet = Boundary("Internet")
         server_db = Boundary("Server/DB")
         user = Actor("User", inBoundary=internet)
@@ -47,7 +48,7 @@ class TestTM(unittest.TestCase):
         Dataflow(db, web, "Retrieve comments")
         Dataflow(web, user, "Show comments (*)")
 
-        tm.check()
+        self.assertTrue(tm.check())
         output = tm.seq()
 
         self.maxDiff = None
@@ -73,7 +74,7 @@ class TestTM(unittest.TestCase):
         Dataflow(db, web, "Retrieve comments")
         Dataflow(web, user, "Show comments (*)")
 
-        tm.check()
+        self.assertTrue(tm.check())
         output = tm.seq()
 
         self.maxDiff = None
@@ -99,7 +100,7 @@ class TestTM(unittest.TestCase):
         Dataflow(db, web, "Retrieve comments")
         Dataflow(web, user, "Show comments (*)")
 
-        tm.check()
+        self.assertTrue(tm.check())
         output = tm.dfd()
 
         self.maxDiff = None


### PR DESCRIPTION
Use numbered dataflow labels on seq diagram. This makes it easier to read when comparing seq and dfd diagrams.

Please note that changes here are very similar to what's proposed in #80, that is:
* moving label and color functions to methods of the `Element` class
* adding shape and display_name methods
which makes it even easier to override classes. As a side effect, `_dfd()` method has been removed from most classes since it's a duplicate now.

This also has the same fix as #93 but that other PR is way simpler and might be merged earlier.

Preview:
![seq](https://user-images.githubusercontent.com/795177/77679492-e4a2bc00-6f92-11ea-9b33-13f2c9d5082b.png)
