### PR TITLE
render collapsed responses arrows as open

### DIFF
--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -387,7 +387,7 @@ class TM():
     def dfd(self):
         print("digraph tm {\n\tgraph [\n\tfontname = Arial;\n\tfontsize = 14;\n\t]")
         print("\tnode [\n\tfontname = Arial;\n\tfontsize = 14;\n\trankdir = lr;\n\t]")
-        print("\tedge [\n\tshape = none;\n\tfontname = Arial;\n\tfontsize = 12;\n\t]")
+        print("\tedge [\n\tshape = none;\n\tarrowtail = onormal;\n\tfontname = Arial;\n\tfontsize = 12;\n\t]")
         print('\tlabelloc = "t";\n\tfontsize = 20;\n\tnodesep = 1;\n')
         for b in TM._BagOfBoundaries:
             b.dfd()

--- a/tests/dfd.dot
+++ b/tests/dfd.dot
@@ -10,6 +10,7 @@ digraph tm {
 	]
 	edge [
 	shape = none;
+	arrowtail = onormal;
 	fontname = Arial;
 	fontsize = 12;
 	]


### PR DESCRIPTION
render collapsed responses arrows as open:

![dfd](https://user-images.githubusercontent.com/795177/78151906-66826180-7439-11ea-956c-f3cbe3c20c49.png)
