### PR TITLE
Fixed setup.py to install deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,14 @@
 import setuptools
 
+with open('README.md', 'r', encoding='utf-8') as f:
+    long_description = f.read()
+
 setuptools.setup(
     name='pytm',
     version='1.1',
     packages=['pytm'],
     description='A Python-based framework for threat modeling.',
-    long_description=open('README.md').read(),
+    long_description=long_description,
     long_description_content_type='text/markdown',
     license='MIT License',
     url="https://github.com/izar/pytm",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setuptools.setup(
     name='pytm',
     version='1.1',
     packages=['pytm'],
-    summary='A Python-based framework for threat modeling.',
+    description='A Python-based framework for threat modeling.',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     license='MIT License',
@@ -20,6 +20,7 @@ setuptools.setup(
         "Natural Language :: English",
     ],
     python_requires='>=3',
+    install_requires=['pydal>=20200714.1'],
     package_data={
         'pytm': ['images/lambda.png', 'threatlib/threats.json'],
     },


### PR DESCRIPTION
Added the install_requires line needed to install pypi dependencies and
opportunistically fixed the usage of `summary` which isn't recognized by
dist/setuptools and used `description` instead.