### PR TITLE
delete unused attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ The available properties of an element can be listed by using `--describe` follo
 
 (pytm) ➜  pytm git:(master) ✗ ./tm.py --describe Element
 Element class attributes:
-  OS
   definesConnectionTimeout        default: False
   description
   handlesResources                default: False
@@ -53,10 +52,8 @@ Element class attributes:
   implementsNonce                 default: False
   inBoundary
   inScope                         Is the element in scope of the threat model, default: True
-  isAdmin                         default: False
   isHardened                      default: False
   name                            required
-  onAWS                           default: False
 
 ```
 
@@ -83,14 +80,11 @@ user = Actor("User")
 user.inBoundary = User_Web
 
 web = Server("Web Server")
-web.OS = "CloudOS"
 web.isHardened = True
 
 db = Datastore("SQL Database (*)")
-db.OS = "CentOS"
 db.isHardened = False
 db.inBoundary = Web_DB
-db.isSql = True
 db.inScope = False
 
 my_lambda = Lambda("cleanDBevery6hours")
@@ -261,7 +255,7 @@ If `target` is a Dataflow, remember you can access `target.source` and/or `targe
 Conditions on assets can analyze all incoming and outgoing Dataflows by inspecting
 the `target.input` and `target.output` attributes. For example, to match a threat only against
 servers with incoming traffic, use `any(target.inputs)`. A more advanced example,
-matching elements connecting to SQL datastores, would be `any(f.sink.oneOf(Datastore) and f.sink.isSQL for f in target.outputs)`.
+matching elements connecting to SQL datastores, would be `any(f.sink.oneOf(Datastore) for f in target.outputs) and target.protocol == 'SQL'`.
 
 ## Currently supported threats
 

--- a/docs/pytm/index.html
+++ b/docs/pytm/index.html
@@ -198,7 +198,6 @@ for example by verifying the authenticity of a digital certificate.&#34;&#34;&#3
         doc=&#34;&#34;&#34;Correctly checks the revocation status
 of credentials used to authenticate the destination&#34;&#34;&#34;,
     )
-    isAdmin = varBool(False)
     # should not be settable, but accessible
     providesIntegrity = False
 
@@ -271,22 +270,6 @@ of credentials used to authenticate the destination</p></div>
 <dt id="pytm.Actor.inputs"><code class="name">var <span class="ident">inputs</span></code></dt>
 <dd>
 <div class="desc"><p>incoming Dataflows</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Actor.isAdmin"><code class="name">var <span class="ident">isAdmin</span></code></dt>
-<dd>
-<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -644,10 +627,8 @@ for example by verifying the authenticity of a digital certificate.&#34;&#34;&#3
         doc=&#34;&#34;&#34;Correctly checks the revocation status
 of credentials used to authenticate the destination&#34;&#34;&#34;,
     )
-    authenticatedWith = varBool(False)
     order = varInt(-1, doc=&#34;Number of this data flow in the threat model&#34;)
     implementsAuthenticationScheme = varBool(False)
-    implementsCommunicationProtocol = varBool(False)
     note = varString(&#34;&#34;)
     usesVPN = varBool(False)
     authorizesSource = varBool(False)
@@ -708,22 +689,6 @@ of credentials used to authenticate the destination&#34;&#34;&#34;,
 </ul>
 <h3>Instance variables</h3>
 <dl>
-<dt id="pytm.Dataflow.authenticatedWith"><code class="name">var <span class="ident">authenticatedWith</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
 <dt id="pytm.Dataflow.authenticatesDestination"><code class="name">var <span class="ident">authenticatesDestination</span></code></dt>
 <dd>
 <div class="desc"><p>Verifies the identity of the destination,
@@ -807,22 +772,6 @@ of credentials used to authenticate the destination</p></div>
 </details>
 </dd>
 <dt id="pytm.Dataflow.implementsAuthenticationScheme"><code class="name">var <span class="ident">implementsAuthenticationScheme</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Dataflow.implementsCommunicationProtocol"><code class="name">var <span class="ident">implementsCommunicationProtocol</span></code></dt>
 <dd>
 <div class="desc"></div>
 <details class="source">
@@ -1097,22 +1046,10 @@ of credentials used to authenticate the destination</p></div>
 <pre><code class="python">class Datastore(Asset):
     &#34;&#34;&#34;An entity storing data&#34;&#34;&#34;
 
-    onRDS = varBool(False)
-    storesLogData = varBool(False)
-    storesPII = varBool(
-        False,
-        doc=&#34;&#34;&#34;Personally Identifiable Information
-is any information relating to an identifiable person.&#34;&#34;&#34;,
-    )
-    storesSensitiveData = varBool(False)
-    isSQL = varBool(True)
-    providesConfidentiality = varBool(False)
     providesIntegrity = varBool(False)
     isShared = varBool(False)
-    hasWriteAccess = varBool(False)
     handlesResourceConsumption = varBool(False)
     isResilient = varBool(False)
-    handlesInterruptions = varBool(False)
     usesEncryptionAlgorithm = varString(&#34;&#34;)
     implementsPOLP = varBool(
         False,
@@ -1150,39 +1087,7 @@ that are necessary for its legitimate purpose.&#34;&#34;&#34;,
 </ul>
 <h3>Instance variables</h3>
 <dl>
-<dt id="pytm.Datastore.handlesInterruptions"><code class="name">var <span class="ident">handlesInterruptions</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
 <dt id="pytm.Datastore.handlesResourceConsumption"><code class="name">var <span class="ident">handlesResourceConsumption</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Datastore.hasWriteAccess"><code class="name">var <span class="ident">hasWriteAccess</span></code></dt>
 <dd>
 <div class="desc"></div>
 <details class="source">
@@ -1235,22 +1140,6 @@ that are necessary for its legitimate purpose.</p></div>
     return self.data.get(instance, self.default)</code></pre>
 </details>
 </dd>
-<dt id="pytm.Datastore.isSQL"><code class="name">var <span class="ident">isSQL</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
 <dt id="pytm.Datastore.isShared"><code class="name">var <span class="ident">isShared</span></code></dt>
 <dd>
 <div class="desc"></div>
@@ -1267,88 +1156,7 @@ that are necessary for its legitimate purpose.</p></div>
     return self.data.get(instance, self.default)</code></pre>
 </details>
 </dd>
-<dt id="pytm.Datastore.onRDS"><code class="name">var <span class="ident">onRDS</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Datastore.providesConfidentiality"><code class="name">var <span class="ident">providesConfidentiality</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
 <dt id="pytm.Datastore.providesIntegrity"><code class="name">var <span class="ident">providesIntegrity</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Datastore.storesLogData"><code class="name">var <span class="ident">storesLogData</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Datastore.storesPII"><code class="name">var <span class="ident">storesPII</span></code></dt>
-<dd>
-<div class="desc"><p>Personally Identifiable Information
-is any information relating to an identifiable person.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Datastore.storesSensitiveData"><code class="name">var <span class="ident">storesSensitiveData</span></code></dt>
 <dd>
 <div class="desc"></div>
 <details class="source">
@@ -1819,7 +1627,6 @@ is any information relating to an identifiable person.</p></div>
 <pre><code class="python">class Lambda(Asset):
     &#34;&#34;&#34;A lambda function running in a Function-as-a-Service (FaaS) environment&#34;&#34;&#34;
 
-    onAWS = varBool(True)
     environment = varString(&#34;&#34;)
     implementsAPI = varBool(False)
 
@@ -1894,22 +1701,6 @@ is any information relating to an identifiable person.</p></div>
     return self.data.get(instance, self.default)</code></pre>
 </details>
 </dd>
-<dt id="pytm.Lambda.onAWS"><code class="name">var <span class="ident">onAWS</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
 </dl>
 </dd>
 <dt id="pytm.Process"><code class="flex name class">
@@ -1925,16 +1716,10 @@ is any information relating to an identifiable person.</p></div>
 <pre><code class="python">class Process(Asset):
     &#34;&#34;&#34;An entity processing data&#34;&#34;&#34;
 
-    codeType = varString(&#34;Unmanaged&#34;)
-    implementsCommunicationProtocol = varBool(False)
-    providesConfidentiality = varBool(False)
     providesIntegrity = varBool(False)
     isResilient = varBool(False)
-    tracksExecutionFlow = varBool(False)
     implementsCSRFToken = varBool(False)
     handlesResourceConsumption = varBool(False)
-    handlesCrashes = varBool(False)
-    handlesInterruptions = varBool(False)
     implementsAPI = varBool(False)
     usesSecureFunctions = varBool(False)
     environment = varString(&#34;&#34;)
@@ -1981,22 +1766,6 @@ and only the user has), and inherence (something the user and only the user is).
 <h3>Instance variables</h3>
 <dl>
 <dt id="pytm.Process.allowsClientSideScripting"><code class="name">var <span class="ident">allowsClientSideScripting</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Process.codeType"><code class="name">var <span class="ident">codeType</span></code></dt>
 <dd>
 <div class="desc"></div>
 <details class="source">
@@ -2076,38 +1845,6 @@ and only the user has), and inherence (something the user and only the user is).
     return self.data.get(instance, self.default)</code></pre>
 </details>
 </dd>
-<dt id="pytm.Process.handlesCrashes"><code class="name">var <span class="ident">handlesCrashes</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Process.handlesInterruptions"><code class="name">var <span class="ident">handlesInterruptions</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
 <dt id="pytm.Process.handlesResourceConsumption"><code class="name">var <span class="ident">handlesResourceConsumption</span></code></dt>
 <dd>
 <div class="desc"></div>
@@ -2141,22 +1878,6 @@ and only the user has), and inherence (something the user and only the user is).
 </details>
 </dd>
 <dt id="pytm.Process.implementsCSRFToken"><code class="name">var <span class="ident">implementsCSRFToken</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Process.implementsCommunicationProtocol"><code class="name">var <span class="ident">implementsCommunicationProtocol</span></code></dt>
 <dd>
 <div class="desc"></div>
 <details class="source">
@@ -2209,39 +1930,7 @@ that are necessary for its legitimate purpose.</p></div>
     return self.data.get(instance, self.default)</code></pre>
 </details>
 </dd>
-<dt id="pytm.Process.providesConfidentiality"><code class="name">var <span class="ident">providesConfidentiality</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
 <dt id="pytm.Process.providesIntegrity"><code class="name">var <span class="ident">providesIntegrity</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Process.tracksExecutionFlow"><code class="name">var <span class="ident">tracksExecutionFlow</span></code></dt>
 <dd>
 <div class="desc"></div>
 <details class="source">
@@ -2356,7 +2045,6 @@ and only the user has), and inherence (something the user and only the user is).
 <pre><code class="python">class Server(Asset):
     &#34;&#34;&#34;An entity processing data&#34;&#34;&#34;
 
-    providesConfidentiality = varBool(False)
     providesIntegrity = varBool(False)
     validatesHeaders = varBool(False)
     encodesHeaders = varBool(False)
@@ -2516,22 +2204,6 @@ that are necessary for its legitimate purpose.</p></div>
 </details>
 </dd>
 <dt id="pytm.Server.isResilient"><code class="name">var <span class="ident">isResilient</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Server.providesConfidentiality"><code class="name">var <span class="ident">providesConfidentiality</span></code></dt>
 <dd>
 <div class="desc"></div>
 <details class="source">
@@ -3655,7 +3327,6 @@ to a boolean True or False</p></div>
 <li><code><a title="pytm.Actor.checksDestinationRevocation" href="#pytm.Actor.checksDestinationRevocation">checksDestinationRevocation</a></code></li>
 <li><code><a title="pytm.Actor.data" href="#pytm.Actor.data">data</a></code></li>
 <li><code><a title="pytm.Actor.inputs" href="#pytm.Actor.inputs">inputs</a></code></li>
-<li><code><a title="pytm.Actor.isAdmin" href="#pytm.Actor.isAdmin">isAdmin</a></code></li>
 <li><code><a title="pytm.Actor.outputs" href="#pytm.Actor.outputs">outputs</a></code></li>
 <li><code><a title="pytm.Actor.port" href="#pytm.Actor.port">port</a></code></li>
 <li><code><a title="pytm.Actor.protocol" href="#pytm.Actor.protocol">protocol</a></code></li>
@@ -3692,7 +3363,6 @@ to a boolean True or False</p></div>
 <li>
 <h4><code><a title="pytm.Dataflow" href="#pytm.Dataflow">Dataflow</a></code></h4>
 <ul class="">
-<li><code><a title="pytm.Dataflow.authenticatedWith" href="#pytm.Dataflow.authenticatedWith">authenticatedWith</a></code></li>
 <li><code><a title="pytm.Dataflow.authenticatesDestination" href="#pytm.Dataflow.authenticatesDestination">authenticatesDestination</a></code></li>
 <li><code><a title="pytm.Dataflow.authorizesSource" href="#pytm.Dataflow.authorizesSource">authorizesSource</a></code></li>
 <li><code><a title="pytm.Dataflow.checksDestinationRevocation" href="#pytm.Dataflow.checksDestinationRevocation">checksDestinationRevocation</a></code></li>
@@ -3701,7 +3371,6 @@ to a boolean True or False</p></div>
 <li><code><a title="pytm.Dataflow.dstPort" href="#pytm.Dataflow.dstPort">dstPort</a></code></li>
 <li><code><a title="pytm.Dataflow.hasDataLeaks" href="#pytm.Dataflow.hasDataLeaks">hasDataLeaks</a></code></li>
 <li><code><a title="pytm.Dataflow.implementsAuthenticationScheme" href="#pytm.Dataflow.implementsAuthenticationScheme">implementsAuthenticationScheme</a></code></li>
-<li><code><a title="pytm.Dataflow.implementsCommunicationProtocol" href="#pytm.Dataflow.implementsCommunicationProtocol">implementsCommunicationProtocol</a></code></li>
 <li><code><a title="pytm.Dataflow.isEncrypted" href="#pytm.Dataflow.isEncrypted">isEncrypted</a></code></li>
 <li><code><a title="pytm.Dataflow.isResponse" href="#pytm.Dataflow.isResponse">isResponse</a></code></li>
 <li><code><a title="pytm.Dataflow.note" href="#pytm.Dataflow.note">note</a></code></li>
@@ -3720,19 +3389,11 @@ to a boolean True or False</p></div>
 <li>
 <h4><code><a title="pytm.Datastore" href="#pytm.Datastore">Datastore</a></code></h4>
 <ul class="">
-<li><code><a title="pytm.Datastore.handlesInterruptions" href="#pytm.Datastore.handlesInterruptions">handlesInterruptions</a></code></li>
 <li><code><a title="pytm.Datastore.handlesResourceConsumption" href="#pytm.Datastore.handlesResourceConsumption">handlesResourceConsumption</a></code></li>
-<li><code><a title="pytm.Datastore.hasWriteAccess" href="#pytm.Datastore.hasWriteAccess">hasWriteAccess</a></code></li>
 <li><code><a title="pytm.Datastore.implementsPOLP" href="#pytm.Datastore.implementsPOLP">implementsPOLP</a></code></li>
 <li><code><a title="pytm.Datastore.isResilient" href="#pytm.Datastore.isResilient">isResilient</a></code></li>
-<li><code><a title="pytm.Datastore.isSQL" href="#pytm.Datastore.isSQL">isSQL</a></code></li>
 <li><code><a title="pytm.Datastore.isShared" href="#pytm.Datastore.isShared">isShared</a></code></li>
-<li><code><a title="pytm.Datastore.onRDS" href="#pytm.Datastore.onRDS">onRDS</a></code></li>
-<li><code><a title="pytm.Datastore.providesConfidentiality" href="#pytm.Datastore.providesConfidentiality">providesConfidentiality</a></code></li>
 <li><code><a title="pytm.Datastore.providesIntegrity" href="#pytm.Datastore.providesIntegrity">providesIntegrity</a></code></li>
-<li><code><a title="pytm.Datastore.storesLogData" href="#pytm.Datastore.storesLogData">storesLogData</a></code></li>
-<li><code><a title="pytm.Datastore.storesPII" href="#pytm.Datastore.storesPII">storesPII</a></code></li>
-<li><code><a title="pytm.Datastore.storesSensitiveData" href="#pytm.Datastore.storesSensitiveData">storesSensitiveData</a></code></li>
 <li><code><a title="pytm.Datastore.usesEncryptionAlgorithm" href="#pytm.Datastore.usesEncryptionAlgorithm">usesEncryptionAlgorithm</a></code></li>
 </ul>
 </li>
@@ -3764,29 +3425,22 @@ to a boolean True or False</p></div>
 <ul class="">
 <li><code><a title="pytm.Lambda.environment" href="#pytm.Lambda.environment">environment</a></code></li>
 <li><code><a title="pytm.Lambda.implementsAPI" href="#pytm.Lambda.implementsAPI">implementsAPI</a></code></li>
-<li><code><a title="pytm.Lambda.onAWS" href="#pytm.Lambda.onAWS">onAWS</a></code></li>
 </ul>
 </li>
 <li>
 <h4><code><a title="pytm.Process" href="#pytm.Process">Process</a></code></h4>
 <ul class="">
 <li><code><a title="pytm.Process.allowsClientSideScripting" href="#pytm.Process.allowsClientSideScripting">allowsClientSideScripting</a></code></li>
-<li><code><a title="pytm.Process.codeType" href="#pytm.Process.codeType">codeType</a></code></li>
 <li><code><a title="pytm.Process.disablesiFrames" href="#pytm.Process.disablesiFrames">disablesiFrames</a></code></li>
 <li><code><a title="pytm.Process.encryptsCookies" href="#pytm.Process.encryptsCookies">encryptsCookies</a></code></li>
 <li><code><a title="pytm.Process.encryptsSessionData" href="#pytm.Process.encryptsSessionData">encryptsSessionData</a></code></li>
 <li><code><a title="pytm.Process.environment" href="#pytm.Process.environment">environment</a></code></li>
-<li><code><a title="pytm.Process.handlesCrashes" href="#pytm.Process.handlesCrashes">handlesCrashes</a></code></li>
-<li><code><a title="pytm.Process.handlesInterruptions" href="#pytm.Process.handlesInterruptions">handlesInterruptions</a></code></li>
 <li><code><a title="pytm.Process.handlesResourceConsumption" href="#pytm.Process.handlesResourceConsumption">handlesResourceConsumption</a></code></li>
 <li><code><a title="pytm.Process.implementsAPI" href="#pytm.Process.implementsAPI">implementsAPI</a></code></li>
 <li><code><a title="pytm.Process.implementsCSRFToken" href="#pytm.Process.implementsCSRFToken">implementsCSRFToken</a></code></li>
-<li><code><a title="pytm.Process.implementsCommunicationProtocol" href="#pytm.Process.implementsCommunicationProtocol">implementsCommunicationProtocol</a></code></li>
 <li><code><a title="pytm.Process.implementsPOLP" href="#pytm.Process.implementsPOLP">implementsPOLP</a></code></li>
 <li><code><a title="pytm.Process.isResilient" href="#pytm.Process.isResilient">isResilient</a></code></li>
-<li><code><a title="pytm.Process.providesConfidentiality" href="#pytm.Process.providesConfidentiality">providesConfidentiality</a></code></li>
 <li><code><a title="pytm.Process.providesIntegrity" href="#pytm.Process.providesIntegrity">providesIntegrity</a></code></li>
-<li><code><a title="pytm.Process.tracksExecutionFlow" href="#pytm.Process.tracksExecutionFlow">tracksExecutionFlow</a></code></li>
 <li><code><a title="pytm.Process.usesMFA" href="#pytm.Process.usesMFA">usesMFA</a></code></li>
 <li><code><a title="pytm.Process.usesParameterizedInput" href="#pytm.Process.usesParameterizedInput">usesParameterizedInput</a></code></li>
 <li><code><a title="pytm.Process.usesSecureFunctions" href="#pytm.Process.usesSecureFunctions">usesSecureFunctions</a></code></li>
@@ -3805,7 +3459,6 @@ to a boolean True or False</p></div>
 <li><code><a title="pytm.Server.implementsStrictHTTPValidation" href="#pytm.Server.implementsStrictHTTPValidation">implementsStrictHTTPValidation</a></code></li>
 <li><code><a title="pytm.Server.invokesScriptFilters" href="#pytm.Server.invokesScriptFilters">invokesScriptFilters</a></code></li>
 <li><code><a title="pytm.Server.isResilient" href="#pytm.Server.isResilient">isResilient</a></code></li>
-<li><code><a title="pytm.Server.providesConfidentiality" href="#pytm.Server.providesConfidentiality">providesConfidentiality</a></code></li>
 <li><code><a title="pytm.Server.providesIntegrity" href="#pytm.Server.providesIntegrity">providesIntegrity</a></code></li>
 <li><code><a title="pytm.Server.usesCache" href="#pytm.Server.usesCache">usesCache</a></code></li>
 <li><code><a title="pytm.Server.usesCodeSigning" href="#pytm.Server.usesCodeSigning">usesCodeSigning</a></code></li>

--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -1041,7 +1041,6 @@ class Asset(Element):
     data = varData([], doc="Default type of data in incoming data flows")
     inputs = varElements([], doc="incoming Dataflows")
     outputs = varElements([], doc="outgoing Dataflows")
-    onAWS = varBool(False)
     isHardened = varBool(False)
     implementsAuthenticationScheme = varBool(False)
     implementsNonce = varBool(
@@ -1073,16 +1072,13 @@ of credentials used to authenticate the destination""",
     checksInputBounds = varBool(False)
     encodesOutput = varBool(False)
     handlesResourceConsumption = varBool(False)
-    authenticationScheme = varString("")
     usesEnvironmentVariables = varBool(False)
-    OS = varString("")
     providesIntegrity = varBool(False)
 
 
 class Lambda(Asset):
     """A lambda function running in a Function-as-a-Service (FaaS) environment"""
 
-    onAWS = varBool(True)
     environment = varString("")
     implementsAPI = varBool(False)
 
@@ -1127,7 +1123,6 @@ class Lambda(Asset):
 class Server(Asset):
     """An entity processing data"""
 
-    providesConfidentiality = varBool(False)
     providesIntegrity = varBool(False)
     validatesHeaders = varBool(False)
     encodesHeaders = varBool(False)
@@ -1173,22 +1168,10 @@ class ExternalEntity(Asset):
 class Datastore(Asset):
     """An entity storing data"""
 
-    onRDS = varBool(False)
-    storesLogData = varBool(False)
-    storesPII = varBool(
-        False,
-        doc="""Personally Identifiable Information
-is any information relating to an identifiable person.""",
-    )
-    storesSensitiveData = varBool(False)
-    isSQL = varBool(True)
-    providesConfidentiality = varBool(False)
     providesIntegrity = varBool(False)
     isShared = varBool(False)
-    hasWriteAccess = varBool(False)
     handlesResourceConsumption = varBool(False)
     isResilient = varBool(False)
-    handlesInterruptions = varBool(False)
     usesEncryptionAlgorithm = varString("")
     implementsPOLP = varBool(
         False,
@@ -1238,7 +1221,6 @@ for example by verifying the authenticity of a digital certificate.""",
         doc="""Correctly checks the revocation status
 of credentials used to authenticate the destination""",
     )
-    isAdmin = varBool(False)
     # should not be settable, but accessible
     providesIntegrity = False
 
@@ -1249,16 +1231,10 @@ of credentials used to authenticate the destination""",
 class Process(Asset):
     """An entity processing data"""
 
-    codeType = varString("Unmanaged")
-    implementsCommunicationProtocol = varBool(False)
-    providesConfidentiality = varBool(False)
     providesIntegrity = varBool(False)
     isResilient = varBool(False)
-    tracksExecutionFlow = varBool(False)
     implementsCSRFToken = varBool(False)
     handlesResourceConsumption = varBool(False)
-    handlesCrashes = varBool(False)
-    handlesInterruptions = varBool(False)
     implementsAPI = varBool(False)
     usesSecureFunctions = varBool(False)
     environment = varString("")
@@ -1325,10 +1301,8 @@ for example by verifying the authenticity of a digital certificate.""",
         doc="""Correctly checks the revocation status
 of credentials used to authenticate the destination""",
     )
-    authenticatedWith = varBool(False)
     order = varInt(-1, doc="Number of this data flow in the threat model")
     implementsAuthenticationScheme = varBool(False)
-    implementsCommunicationProtocol = varBool(False)
     note = varString("")
     usesVPN = varBool(False)
     authorizesSource = varBool(False)

--- a/tests/output.json
+++ b/tests/output.json
@@ -51,7 +51,6 @@
             "inputs": [
                 "Show comments (*)"
             ],
-            "isAdmin": false,
             "levels": [
                 0
             ],
@@ -65,11 +64,9 @@
             "providesIntegrity": false
         },
         {
-            "OS": "",
             "__class__": "Server",
             "authenticatesDestination": false,
             "authenticatesSource": false,
-            "authenticationScheme": "",
             "authorizesSource": false,
             "checksDestinationRevocation": false,
             "checksInputBounds": false,
@@ -104,7 +101,6 @@
             ],
             "maxClassification": "Classification.UNKNOWN",
             "name": "Web Server",
-            "onAWS": false,
             "outputs": [
                 "Insert query with comments",
                 "Call func",
@@ -112,7 +108,6 @@
             ],
             "port": -1,
             "protocol": "",
-            "providesConfidentiality": false,
             "providesIntegrity": false,
             "sanitizesInput": false,
             "usesCache": false,
@@ -129,11 +124,9 @@
             "validatesInput": false
         },
         {
-            "OS": "",
             "__class__": "Lambda",
             "authenticatesDestination": false,
             "authenticatesSource": false,
-            "authenticationScheme": "",
             "authorizesSource": false,
             "checksDestinationRevocation": false,
             "checksInputBounds": false,
@@ -161,7 +154,6 @@
             ],
             "maxClassification": "Classification.UNKNOWN",
             "name": "Lambda func",
-            "onAWS": true,
             "outputs": [],
             "port": -1,
             "protocol": "",
@@ -171,16 +163,13 @@
             "validatesInput": false
         },
         {
-            "OS": "",
             "__class__": "Process",
             "allowsClientSideScripting": false,
             "authenticatesDestination": false,
             "authenticatesSource": false,
-            "authenticationScheme": "",
             "authorizesSource": false,
             "checksDestinationRevocation": false,
             "checksInputBounds": false,
-            "codeType": "Unmanaged",
             "data": [],
             "definesConnectionTimeout": false,
             "description": "",
@@ -190,15 +179,12 @@
             "encryptsSessionData": false,
             "environment": "",
             "findings": [],
-            "handlesCrashes": false,
-            "handlesInterruptions": false,
             "handlesResourceConsumption": false,
             "handlesResources": false,
             "hasAccessControl": false,
             "implementsAPI": false,
             "implementsAuthenticationScheme": false,
             "implementsCSRFToken": false,
-            "implementsCommunicationProtocol": false,
             "implementsNonce": false,
             "implementsPOLP": false,
             "inBoundary": null,
@@ -212,16 +198,13 @@
             ],
             "maxClassification": "Classification.UNKNOWN",
             "name": "Task queue worker",
-            "onAWS": false,
             "outputs": [
                 "Query for tasks"
             ],
             "port": -1,
             "protocol": "",
-            "providesConfidentiality": false,
             "providesIntegrity": false,
             "sanitizesInput": false,
-            "tracksExecutionFlow": false,
             "usesEnvironmentVariables": false,
             "usesMFA": false,
             "usesParameterizedInput": false,
@@ -231,11 +214,9 @@
             "verifySessionIdentifiers": false
         },
         {
-            "OS": "",
             "__class__": "Datastore",
             "authenticatesDestination": false,
             "authenticatesSource": false,
-            "authenticationScheme": "",
             "authorizesSource": false,
             "checksDestinationRevocation": false,
             "checksInputBounds": false,
@@ -244,11 +225,9 @@
             "description": "",
             "encodesOutput": false,
             "findings": [],
-            "handlesInterruptions": false,
             "handlesResourceConsumption": false,
             "handlesResources": false,
             "hasAccessControl": false,
-            "hasWriteAccess": false,
             "implementsAuthenticationScheme": false,
             "implementsNonce": false,
             "implementsPOLP": false,
@@ -261,26 +240,19 @@
             "isEncrypted": false,
             "isHardened": false,
             "isResilient": false,
-            "isSQL": true,
             "isShared": false,
             "levels": [
                 0
             ],
             "maxClassification": "Classification.UNKNOWN",
             "name": "SQL Database",
-            "onAWS": false,
-            "onRDS": false,
             "outputs": [
                 "Retrieve comments"
             ],
             "port": -1,
             "protocol": "",
-            "providesConfidentiality": false,
             "providesIntegrity": false,
             "sanitizesInput": false,
-            "storesLogData": false,
-            "storesPII": false,
-            "storesSensitiveData": false,
             "usesEncryptionAlgorithm": "",
             "usesEnvironmentVariables": false,
             "validatesInput": false
@@ -289,7 +261,6 @@
     "findings": [],
     "flows": [
         {
-            "authenticatedWith": false,
             "authenticatesDestination": false,
             "authorizesSource": false,
             "checksDestinationRevocation": false,
@@ -300,7 +271,6 @@
             "dstPort": -1,
             "findings": [],
             "implementsAuthenticationScheme": false,
-            "implementsCommunicationProtocol": false,
             "inBoundary": null,
             "inScope": true,
             "isEncrypted": false,
@@ -323,7 +293,6 @@
             "usesVPN": false
         },
         {
-            "authenticatedWith": false,
             "authenticatesDestination": false,
             "authorizesSource": false,
             "checksDestinationRevocation": false,
@@ -332,7 +301,6 @@
             "dstPort": -1,
             "findings": [],
             "implementsAuthenticationScheme": false,
-            "implementsCommunicationProtocol": false,
             "inBoundary": null,
             "inScope": true,
             "isEncrypted": false,
@@ -355,7 +323,6 @@
             "usesVPN": false
         },
         {
-            "authenticatedWith": false,
             "authenticatesDestination": false,
             "authorizesSource": false,
             "checksDestinationRevocation": false,
@@ -364,7 +331,6 @@
             "dstPort": -1,
             "findings": [],
             "implementsAuthenticationScheme": false,
-            "implementsCommunicationProtocol": false,
             "inBoundary": null,
             "inScope": true,
             "isEncrypted": false,
@@ -387,7 +353,6 @@
             "usesVPN": false
         },
         {
-            "authenticatedWith": false,
             "authenticatesDestination": false,
             "authorizesSource": false,
             "checksDestinationRevocation": false,
@@ -396,7 +361,6 @@
             "dstPort": -1,
             "findings": [],
             "implementsAuthenticationScheme": false,
-            "implementsCommunicationProtocol": false,
             "inBoundary": null,
             "inScope": true,
             "isEncrypted": false,
@@ -419,7 +383,6 @@
             "usesVPN": false
         },
         {
-            "authenticatedWith": false,
             "authenticatesDestination": false,
             "authorizesSource": false,
             "checksDestinationRevocation": false,
@@ -428,7 +391,6 @@
             "dstPort": -1,
             "findings": [],
             "implementsAuthenticationScheme": false,
-            "implementsCommunicationProtocol": false,
             "inBoundary": null,
             "inScope": true,
             "isEncrypted": false,
@@ -451,7 +413,6 @@
             "usesVPN": false
         },
         {
-            "authenticatedWith": false,
             "authenticatesDestination": false,
             "authorizesSource": false,
             "checksDestinationRevocation": false,
@@ -460,7 +421,6 @@
             "dstPort": -1,
             "findings": [],
             "implementsAuthenticationScheme": false,
-            "implementsCommunicationProtocol": false,
             "inBoundary": null,
             "inScope": true,
             "isEncrypted": false,

--- a/tests/test_private_func.py
+++ b/tests/test_private_func.py
@@ -35,12 +35,12 @@ class TestAttributes(unittest.TestCase):
             user.name = "Computer"
 
     def test_kwargs(self):
-        user = Actor("User", isAdmin=True)
-        self.assertEqual(user.isAdmin, True)
+        user = Actor("User", authenticatesDestination=True)
+        self.assertEqual(user.authenticatesDestination, True)
         user = Actor("User")
-        self.assertEqual(user.isAdmin, False)
-        user.isAdmin = True
-        self.assertEqual(user.isAdmin, True)
+        self.assertEqual(user.authenticatesDestination, False)
+        user.authenticatesDestination = True
+        self.assertEqual(user.authenticatesDestination, True)
 
     def test_load_threats(self):
         tm = TM("TM")
@@ -85,7 +85,6 @@ class TestAttributes(unittest.TestCase):
         )
         db = Datastore(
             "PostgreSQL",
-            isSQL=True,
             port=5432,
             protocol="PostgreSQL",
             isEncrypted=False,
@@ -178,7 +177,7 @@ class TestMethod(unittest.TestCase):
 
         user = Actor("User", inBoundary=internet)
         server = Server("Server")
-        db = Datastore("DB", inBoundary=cloud, isSQL=True)
+        db = Datastore("DB", inBoundary=cloud)
         func = Datastore("Lambda function", inBoundary=cloud)
 
         request = Dataflow(user, server, "request")
@@ -205,7 +204,7 @@ class TestMethod(unittest.TestCase):
             {"target": func, "condition": "not any(target.inputs)"},
             {
                 "target": server,
-                "condition": "any(f.sink.oneOf(Datastore) and f.sink.isSQL "
+                "condition": "any(f.sink.oneOf(Datastore) "
                 "for f in target.outputs)",
             },
         ]

--- a/tm.py
+++ b/tm.py
@@ -27,28 +27,22 @@ user.inBoundary = internet
 user.levels = [2]
 
 web = Server("Web Server")
-web.OS = "Ubuntu"
 web.isHardened = True
 web.sanitizesInput = False
 web.encodesOutput = True
 web.authorizesSource = False
 
 db = Datastore("SQL Database")
-db.OS = "CentOS"
 db.isHardened = False
 db.inBoundary = server_db
-db.isSQL = True
 db.inScope = True
 db.maxClassification = Classification.RESTRICTED
 db.levels = [2]
 
 secretDb = Datastore("Real Identity Database")
-secretDb.OS = "CentOS"
 secretDb.isHardened = True
 secretDb.inBoundary = server_db
-secretDb.isSQL = True
 secretDb.inScope = True
-secretDb.storesPII = True
 secretDb.maxClassification = Classification.TOP_SECRET
 
 my_lambda = Lambda("AWS Lambda")


### PR DESCRIPTION
The following attributes are not used in any threat. Using them in models can create a false sense of security where no new findings would be reported.

- authenticatedWith
- authenticationScheme
- codeType
- handlesCrashes
- handlesInterruptions
- hasWriteAccess
- implementsCommunicationProtocol
- isAdmin
- isSQL
- onAWS
- onRDS
- OS
- providesConfidentiality
- storesLogData
- storesPII
- storesSensitiveData
- tracksExecutionFlow

Its pretty easy for anyone to extend pytm classes and add these back when referencing them in custom threats. I believe that extending pytm this way should be encouraged.

This is controversial but it's easier to remove unused attributes than try to figure out correct description for them. Less is more.