### PR TITLE
Fixed the alignment of the element description

### DIFF
--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -436,12 +436,13 @@ def _describe_classes(classes):
             docs = []
             if isinstance(attr, var):
                 if attr.doc:
-                    docs.append(attr.doc)
+                    docs.extend(attr.doc.split("\n"))
                 if attr.required:
                     docs.append("required")
                 if attr.default or isinstance(attr.default, bool):
                     docs.append("default: {}".format(attr.default))
-            print("  {}{}".format(i.ljust(longest, " "), ", ".join(docs)))
+            lpadding = f'\n{" ":<{longest+2}}'
+            print(f"  {i:<{longest}}{lpadding.join(docs)}")
         print()
 
 


### PR DESCRIPTION
If an element has a long doc string with newlines in it the description
was difficult to read. For example:

```
  credentialsLife          Credentials lifetime, describing if and how
credentials can be revoked. One of:
* NONE - not applicable
* UNKNOWN - unknown lifetime
* HARDCODED - cannot be invalidated at all, default: Lifetime.NONE
```

With this commit the description is aligned with the first line of the
description.
```
  credentialsLife          Credentials lifetime, describing if and how
                           credentials can be revoked. One of:
                           * NONE - not applicable
                           * UNKNOWN - unknown lifetime
                           * HARDCODED - cannot be invalidated at all
                           default: Lifetime.NONE
```

As a side effect the default and required flags are on a
separated line. I think this makes them easier to spot. But this could
be changed with extra code.