### PR TITLE
Add missing _safeset to Data class

### DIFF
--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -1179,6 +1179,12 @@ If only derivative data is stored (a hash) it can be set to False.""",
     def __str__(self):
         return "{0}({1})".format(type(self).__name__, self.name)
 
+    def _safeset(self, attr, value):
+        try:
+            setattr(self, attr, value)
+        except ValueError:
+            pass
+
 
 class Asset(Element):
     """An asset with outgoing or incoming dataflows"""

--- a/tests/test_pytmfunc.py
+++ b/tests/test_pytmfunc.py
@@ -102,11 +102,12 @@ class TestTM(unittest.TestCase):
         user = Actor("User", inBoundary=internet)
         gw = Server("Gateway", inBoundary=dmz)
         web = Server("Web Server", inBoundary=backend)
-        db = Datastore("SQL Database", inBoundary=backend)
+        db = Datastore("SQL Database", inBoundary=backend, isEncryptedAtRest=True)
+        comment = Data("Comment", isStored=True)
 
         Dataflow(user, gw, "User enters comments (*)")
         Dataflow(gw, web, "Request")
-        Dataflow(web, db, "Insert query with comments")
+        Dataflow(web, db, "Insert query with comments", data=[comment])
         Dataflow(db, web, "Retrieve comments")
         Dataflow(web, gw, "Response")
         Dataflow(gw, user, "Show comments (*)")
@@ -896,7 +897,7 @@ class Testpytm(unittest.TestCase):
             sink=Classification.RESTRICTED,
             dataflow=Classification.RESTRICTED,
             data=Classification.RESTRICTED,
-            define_data=True
+            define_data=True,
         ):
             source_ = Server("Source", maxClassification=source)
             sink_ = Datastore("Sink", maxClassification=sink)

--- a/tm.py
+++ b/tm.py
@@ -54,7 +54,7 @@ secretDb.maxClassification = Classification.TOP_SECRET
 my_lambda = Lambda("AWS Lambda")
 my_lambda.hasAccessControl = True
 my_lambda.inBoundary = vpc
-my_lambda.levels = [1,2]
+my_lambda.levels = [1, 2]
 
 db_to_secretDb = Dataflow(db, secretDb, "Database verify real user identity")
 db_to_secretDb.protocol = "RDA-TCP"


### PR DESCRIPTION
When attempting to generate dfd, seq or report with where the datastore has the attribute `isEncryptedAtRest` and data has `isStored` attribute I receive:

```
ERROR: test_dfd (tests.test_pytmfunc.TestTM)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/pytm/tests/test_pytmfunc.py", line 115, in test_dfd
    self.assertTrue(tm.check())
  File "/tmp/pytm/pytm/pytm.py", line 697, in check
    _apply_defaults(TM._flows, TM._data)
  File "/tmp/pytm/pytm/pytm.py", line 378, in _apply_defaults
    d._safeset("isDestEncryptedAtRest", e.sink.isEncryptedAtRest)
AttributeError: 'Data' object has no attribute '_safeset'
```

We're able to reproduce with this short example:
```
web = Server("Server")
db = Datastore("Db", isEncryptedAtRest=True)
data = Data("Data", isStored=True)
dataflow = Dataflow("Server to DB', data=[data])
```

I was unsure which test to extend and I am happy to move to a different one or write a new one.

This appears to be a result of https://github.com/izar/pytm/pull/127

I ran the following before committing:
```
make test
make format
```