### PR TITLE
Add unique Finding ID instead of re-using Threat ID

### DIFF
--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -355,7 +355,7 @@ def _apply_defaults(flows, data):
         try:
             e.overrides = e.sink.overrides
             e.overrides.extend(
-                f for f in e.source.overrides if f.id not in (f.id for f in e.overrides)
+                f for f in e.source.overrides if f.threat_id not in (f.threat_id for f in e.overrides)
             )
         except ValueError:
             pass
@@ -577,7 +577,7 @@ Can be one of:
 
         threat_id = kwargs.get("threat_id", None)
         for f in element.overrides:
-            if f.id != threat_id:
+            if f.threat_id != threat_id:
                 continue
             for i in dir(f.__class__):
                 attr = getattr(f.__class__, i)
@@ -672,11 +672,11 @@ with same properties, except name and notes""",
             if not e.inScope:
                 continue
 
-            override_ids = set(f.id for f in e.overrides)
+            override_ids = set(f.threat_id for f in e.overrides)
             # if element is a dataflow filter out overrides from source and sink
             # because they will be always applied there anyway
             try:
-                override_ids -= set(f.id for f in e.source.overrides + e.sink.overrides)
+                override_ids -= set(f.threat_id for f in e.source.overrides + e.sink.overrides)
             except AttributeError:
                 pass
 
@@ -706,7 +706,7 @@ a brief description of the system being modeled."""
         _apply_defaults(TM._flows, TM._data)
 
         for e in TM._elements:
-            top = Counter(f.id for f in e.overrides).most_common(1)
+            top = Counter(f.threat_id for f in e.overrides).most_common(1)
             if not top:
                 continue
             threat_id, count = top[0]

--- a/tests/test_pytmfunc.py
+++ b/tests/test_pytmfunc.py
@@ -201,16 +201,16 @@ class TestTM(unittest.TestCase):
 
         self.maxDiff = None
         self.assertEqual(
-            [f.id for f in tm.findings],
+            [f.threat_id for f in tm.findings],
             ["Server", "Datastore", "Dataflow", "Dataflow", "Dataflow", "Dataflow"],
         )
-        self.assertEqual([f.id for f in user.findings], [])
-        self.assertEqual([f.id for f in web.findings], ["Server"])
-        self.assertEqual([f.id for f in db.findings], ["Datastore"])
-        self.assertEqual([f.id for f in req.findings], ["Dataflow"])
-        self.assertEqual([f.id for f in query.findings], ["Dataflow"])
-        self.assertEqual([f.id for f in results.findings], ["Dataflow"])
-        self.assertEqual([f.id for f in resp.findings], ["Dataflow"])
+        self.assertEqual([f.threat_id for f in user.findings], [])
+        self.assertEqual([f.threat_id for f in web.findings], ["Server"])
+        self.assertEqual([f.threat_id for f in db.findings], ["Datastore"])
+        self.assertEqual([f.threat_id for f in req.findings], ["Dataflow"])
+        self.assertEqual([f.threat_id for f in query.findings], ["Dataflow"])
+        self.assertEqual([f.threat_id for f in results.findings], ["Dataflow"])
+        self.assertEqual([f.threat_id for f in resp.findings], ["Dataflow"])
 
     def test_overrides(self):
         random.seed(0)
@@ -223,7 +223,7 @@ class TestTM(unittest.TestCase):
         web = Server(
             "Web Server",
             overrides=[
-                Finding(id="Server", response="mitigated by adding TLS"),
+                Finding(threat_id="Server", response="mitigated by adding TLS"),
             ],
         )
         db = Datastore(
@@ -231,7 +231,7 @@ class TestTM(unittest.TestCase):
             inBoundary=server_db,
             overrides=[
                 Finding(
-                    id="Datastore", response="accepted since inside the trust boundary"
+                    threat_id="Datastore", response="accepted since inside the trust boundary"
                 ),
             ],
         )
@@ -249,7 +249,7 @@ class TestTM(unittest.TestCase):
 
         self.maxDiff = None
         self.assertEqual(
-            [f.id for f in tm.findings],
+            [f.threat_id for f in tm.findings],
             ["Server", "Datastore"],
         )
         self.assertEqual(


### PR DESCRIPTION
Currently when parsing JSON the Elements contain a list of findings which references only the Threat Id. Since a Threat and given ID can be assigned via a Finding to different components it is not possible to reference a specific finding.

This adds an incremental id to finding starting a 1. which can be used to retrieve the referenced finding.