### PR TITLE
Fix encoding errors due to compatibility between #151 and #154

### DIFF
--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -508,6 +508,12 @@ to a boolean True or False""",
         self.example = kwargs.get("example", "")
         self.references = kwargs.get("references", "")
 
+    def _safeset(self, attr, value):
+        try:
+            setattr(self, attr, value)
+        except ValueError:
+            pass
+
     def __repr__(self):
         return "<{0}.{1}({2}) at {3}>".format(
             self.__module__, type(self).__name__, self.id, hex(id(self))
@@ -597,6 +603,12 @@ Can be one of:
 
         for k, v in kwargs.items():
             setattr(self, k, v)
+
+    def _safeset(self, attr, value):
+        try:
+            setattr(self, attr, value)
+        except ValueError:
+            pass
 
     def __repr__(self):
         return "<{0}.{1}({2}) at {3}>".format(
@@ -1701,9 +1713,16 @@ def encode_threat_data(obj):
     for e in obj:
         t = copy.deepcopy(e)
 
+        if (isinstance(t, Finding)):
+            attrs.append("threat_id")
+
         for a in attrs:
             v = getattr(e, a)
-            setattr(t, a, html.escape(v))
+
+            if (isinstance(v, int)):
+                t._safeset(a, v)
+            else:
+                t._safeset(a, html.escape(v))
 
         encoded_threat_data.append(t)
 

--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -1706,6 +1706,7 @@ def encode_threat_data(obj):
             "mitigations",
             "example",
             "id",
+            "target",
             "references",
             "condition",
     ]
@@ -1720,6 +1721,8 @@ def encode_threat_data(obj):
             v = getattr(e, a)
 
             if (isinstance(v, int)):
+                t._safeset(a, v)
+            elif (isinstance(v, tuple)):
                 t._safeset(a, v)
             else:
                 t._safeset(a, html.escape(v))


### PR DESCRIPTION
With #154 the `Finding.id` value is not an `int` and `Threat.id` is a `str`, the common encoding method needs to handle `id` differently between the 2 object types.