### PR TITLE
An empty threat model with ignoreUnused throws an error

### DIFF
--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -318,6 +318,8 @@ def _sort(flows, addOrder=False):
 
 
 def _sort_elem(elements):
+    if len(elements) == 0:
+        return elements
     orders = {}
     for e in elements:
         try:


### PR DESCRIPTION
If a model has only elements which will not be displayed because
ignoreUnused is set to True the function _sort_elements() fails.

This is caused by a call to max(orders.values())` which then is
`max([])` which is not a computable value.

The error is caused by a module like this or an empty model.

```
from pytm import (
    TM,
    Actor,
)

tm = TM("my test tm")
tm.ignoreUnused = True

actor = Actor('actor')

if __name__ == "__main__":
    tm.process()
```