### PR TITLE
Fix: Excluded threat IDs are ignored when using --exclude argument

### DIFF
--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -739,6 +739,7 @@ with same properties, except name and notes""",
         cls._threats = []
         cls._boundaries = []
         cls._data = []
+        cls._threatsExcluded = []
 
     def _init_threats(self):
         TM._threats = []

--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -773,6 +773,9 @@ with same properties, except name and notes""",
                 if not t.apply(e) and t.id not in override_ids:
                     continue
 
+                if t.id in TM._threatsExcluded:
+                    continue
+
                 finding_count += 1
                 f = Finding(e, id=str(finding_count), threat=t)
                 findings.append(f)
@@ -981,6 +984,9 @@ a brief description of the system being modeled."""
         if result.debug:
             logger.setLevel(logging.DEBUG)
 
+        if result.exclude is not None:
+            TM._threatsExcluded = result.exclude.split(",")
+
         if result.seq is True:
             print(self.seq())
 
@@ -1004,9 +1010,6 @@ a brief description of the system being modeled."""
 
         if result.report is not None:
             print(self.report(result.report))
-
-        if result.exclude is not None:
-            TM._threatsExcluded = result.exclude.split(",")
 
         if result.describe is not None:
             _describe_classes(result.describe.split())

--- a/tests/test_pytmfunc.py
+++ b/tests/test_pytmfunc.py
@@ -186,6 +186,28 @@ class TestTM(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, e):
             tm.check()
 
+    def test_exclude_threats_ignore(self):
+        random.seed(0)
+
+        TM.reset()
+
+        excluded_threat = "INP03"
+        remaining_threat = "AA01"
+
+        TM._threatsExcluded = [excluded_threat]
+
+        tm = TM("my test tm", description="aaa")
+        web = Server("Web")
+        web.sanitizesInput = False
+        web.encodesOutput = False
+        self.assertTrue(threats[excluded_threat].apply(web))
+        self.assertTrue(threats[remaining_threat].apply(web))
+
+        tm.resolve()
+
+        self.assertNotIn(excluded_threat, [t.threat_id for t in tm.findings])
+        self.assertIn(remaining_threat, [t.threat_id for t in tm.findings])
+
     def test_resolve(self):
         random.seed(0)
 


### PR DESCRIPTION
Hi,

the `--exclude` argument does not have any effect on the output/reports.
I could not find any related issue/pull request so far.

Example:
`python tm.py --exclude DR01,DS06 --report template.md > report.md`

(This should remove the threats *Unprotected Sensitive Data* and *Data Leak* from the list of threats at the sample TM)

The attribute **_threatsExcluded** are set when parsing arguments, but were not used after that.
This was fixed with a simple if-statement when adding threats to the output/report.

However, this also required the argument parsing of excluded threats to be moved further up. Otherwise, reports/output would have been processed before threats are even added to the list of excluded threats as it seems.