### PR TITLE
Adding uniqueId to get static references for findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ tm/
 /tests/1.txt
 /tests/0.txt
 /tests/.config.pytm
+
+# Snyk cache file
+.dccache

--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -1915,8 +1915,8 @@ def encode_element_threat_data(obj):
                v = getattr(o, a)
                if (type(v) is not list or (type(v) is list and len(v) != 0)):
                   c._safeset(a, v)
-
-       encoded_elements.append(c)
+                 
+       encoded_elements.append(c)    
 
     return encoded_elements
 

--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -1320,7 +1320,7 @@ a custom response, CVSS score or override other attributes.""",
     def __init__(self, name, **kwargs):
         for key, value in kwargs.items():
             setattr(self, key, value)
-        self.name = nameUniqueIdFormat.format(name, self.uniqueId)
+        self.name = self.nameUniqueIdFormat.format(name, self.uniqueId)
         self.controls = Controls()
         self.uuid = uuid.UUID(int=random.getrandbits(128))
         self._is_drawn = False

--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -752,6 +752,10 @@ with same properties, except name and notes""",
         doc="A list of assumptions about the design/model.",
     )
     uniqueFindingIdFormat = varString("{0}-{1}", doc="Default formatting of the uniqueId of findings. Argument 0 is the uniqueId of the element the finding is related to and argument 1 is the id of the finding. E.g., if you elements is called E1 and the finding DE01, the uniqueId of the finding becomes E1-DE01. If you prefer say DE01:E1, specify the format as {1}:{0}")
+    nameUniqueIdFormat = varString("{0}-{1}",doc="When addUniqueIdToName is true, this format is used to format the name. Argument 0 is the name property, argument 1 is the uniqueId. The default format is '{0} ({1})' e.g., if the name is MyServer and the uniqueId is S1, the name will become 'MyServer (S1)'. If you want another format, provide your own format string"  )
+
+    addUniqueIdToName = varBool(False,doc="If true, the uniqueId will be added to the name of the element as defined by nameUniqueIdFormat")
+    _test1=nameUniqueIdFormat.data[nameUniqueIdFormat.super().instance]
 
     def __init__(self, name, **kwargs):
         for key, value in kwargs.items():
@@ -762,7 +766,16 @@ with same properties, except name and notes""",
         # make sure generated diagrams do not change, makes sense if they're commited
         random.seed(0)
 
+    @staticmethod
+    def GetAddUniqueIdToName():
+        return addUniqueIdToName
+
+    @staticmethod
+    def GetNameUniqueIdFormat():
+        return nameUniqueIdFormat
+
     @classmethod
+
     def reset(cls):
         cls._flows = []
         cls._elements = []
@@ -1286,7 +1299,6 @@ and only the user has), and inherence (something the user and only the user is).
 
 class Element:
     """A generic element"""
-
     name = varString("", required=True)
     description = varString("")
     inBoundary = varBoundary(None, doc="Trust boundary this element exists in")
@@ -1319,7 +1331,10 @@ a custom response, CVSS score or override other attributes.""",
     def __init__(self, name, **kwargs):
         for key, value in kwargs.items():
             setattr(self, key, value)
-        self.name = name
+        if self.uniqueId and TM.GetAddUniqueIdToName():
+            self.name = TM.GetNameUniqueIdFormat().format(name, self.uniqueId)
+        else:
+            self.name = "the name" + TM._test1
         self.controls = Controls()
         self.uuid = uuid.UUID(int=random.getrandbits(128))
         self._is_drawn = False

--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -36,9 +36,6 @@ from .template_engine import SuperFormatter
 
 logger = logging.getLogger(__name__)
 
-# todo: Sorry, but I could not manage to get the value of a VarString from the Element class so I had to store it globally
-nameUniqueIdFormat_shadow="shadow"
-
 class var(object):
     """A descriptor that allows setting a value only once"""
 
@@ -760,8 +757,6 @@ with same properties, except name and notes""",
         for key, value in kwargs.items():
             setattr(self, key, value)
         self.name = name
-        global nameUniqueIdFormat_shadow
-        nameUniqueIdFormat_shadow=self.nameUniqueIdFormat
         self._sf = SuperFormatter()
         self._add_threats()
         # make sure generated diagrams do not change, makes sense if they're commited
@@ -1290,7 +1285,7 @@ and only the user has), and inherence (something the user and only the user is).
 
 
 
-class Element:
+class Element(TM):
     """A generic element"""
 
     name = varString("", required=True)
@@ -1325,7 +1320,7 @@ a custom response, CVSS score or override other attributes.""",
     def __init__(self, name, **kwargs):
         for key, value in kwargs.items():
             setattr(self, key, value)
-        self.name = nameUniqueIdFormat_shadow.format(name, self.uniqueId)
+        self.name = nameUniqueIdFormat.format(name, self.uniqueId)
         self.controls = Controls()
         self.uuid = uuid.UUID(int=random.getrandbits(128))
         self._is_drawn = False
@@ -1916,8 +1911,8 @@ def encode_element_threat_data(obj):
                v = getattr(o, a)
                if (type(v) is not list or (type(v) is list and len(v) != 0)):
                   c._safeset(a, v)
-                 
-       encoded_elements.append(c)    
+
+       encoded_elements.append(c)
 
     return encoded_elements
 

--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -36,6 +36,8 @@ from .template_engine import SuperFormatter
 
 logger = logging.getLogger(__name__)
 
+# todo: Sorry, but I could not manage to get the value of a VarString from the Element class so I had to store it globally
+nameUniqueIdFormat_shadow="shadow"
 
 class var(object):
     """A descriptor that allows setting a value only once"""
@@ -752,15 +754,14 @@ with same properties, except name and notes""",
         doc="A list of assumptions about the design/model.",
     )
     uniqueFindingIdFormat = varString("{0}-{1}", doc="Default formatting of the uniqueId of findings. Argument 0 is the uniqueId of the element the finding is related to and argument 1 is the id of the finding. E.g., if you elements is called E1 and the finding DE01, the uniqueId of the finding becomes E1-DE01. If you prefer say DE01:E1, specify the format as {1}:{0}")
-    nameUniqueIdFormat = varString("{0}-{1}",doc="When addUniqueIdToName is true, this format is used to format the name. Argument 0 is the name property, argument 1 is the uniqueId. The default format is '{0} ({1})' e.g., if the name is MyServer and the uniqueId is S1, the name will become 'MyServer (S1)'. If you want another format, provide your own format string"  )
-
-    addUniqueIdToName = varBool(False,doc="If true, the uniqueId will be added to the name of the element as defined by nameUniqueIdFormat")
-    _test1=nameUniqueIdFormat.data[nameUniqueIdFormat.super().instance]
+    nameUniqueIdFormat = varString("{0}",doc="This format is used to format the name. Argument 0 is the name property, argument 1 is the uniqueId. The default format is '{0}'. If you specify the uniqueId property on your objects, you can use this to add it to the name. E.g., if the name is MyServer and the uniqueId is S1, the name will become 'MyServer (S1)' if you specify '{0} ({1})' here."  )
 
     def __init__(self, name, **kwargs):
         for key, value in kwargs.items():
             setattr(self, key, value)
         self.name = name
+        global nameUniqueIdFormat_shadow
+        nameUniqueIdFormat_shadow=self.nameUniqueIdFormat
         self._sf = SuperFormatter()
         self._add_threats()
         # make sure generated diagrams do not change, makes sense if they're commited
@@ -1331,10 +1332,7 @@ a custom response, CVSS score or override other attributes.""",
     def __init__(self, name, **kwargs):
         for key, value in kwargs.items():
             setattr(self, key, value)
-        if self.uniqueId and TM.GetAddUniqueIdToName():
-            self.name = TM.GetNameUniqueIdFormat().format(name, self.uniqueId)
-        else:
-            self.name = "the name" + TM._test1
+        self.name = nameUniqueIdFormat_shadow.format(name, self.uniqueId)
         self.controls = Controls()
         self.uuid = uuid.UUID(int=random.getrandbits(128))
         self._is_drawn = False

--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -767,14 +767,6 @@ with same properties, except name and notes""",
         # make sure generated diagrams do not change, makes sense if they're commited
         random.seed(0)
 
-    @staticmethod
-    def GetAddUniqueIdToName():
-        return addUniqueIdToName
-
-    @staticmethod
-    def GetNameUniqueIdFormat():
-        return nameUniqueIdFormat
-
     @classmethod
 
     def reset(cls):

--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -1292,6 +1292,7 @@ and only the user has), and inherence (something the user and only the user is).
 
 class Element:
     """A generic element"""
+
     name = varString("", required=True)
     description = varString("")
     inBoundary = varBoundary(None, doc="Trust boundary this element exists in")

--- a/tests/test_pytmfunc.py
+++ b/tests/test_pytmfunc.py
@@ -292,6 +292,38 @@ class TestTM(unittest.TestCase):
             ["accepted since inside the trust boundary"],
         )
 
+    def test_uniqueid_two_runs(self):
+        # Ensure unique IDs are returned as specified and that it can be done twice in the same run
+        tm = TM("my test tm" )
+        internet = Boundary("Internet",uniqueId="B1")
+        athome = Boundary("athome",uniqueId="B2")
+        user = Actor("user",uniqueId="U1")
+        badactor = Actor("badactor",uniqueId="U2")
+        tm.resolve()
+        self.assertEqual(tm._elements[0].uniqueId, "B1")
+        self.assertEqual(tm._elements[1].uniqueId, "B2")
+        self.assertEqual(tm._elements[2].uniqueId, "U1")
+        self.assertEqual(tm._elements[3].uniqueId, "U2")
+        self.assertEqual(tm._actors[0].uniqueId, "U1")
+        self.assertEqual(tm._actors[1].uniqueId, "U2")
+        self.assertEqual(tm._boundaries[0].uniqueId, "B1")
+        self.assertEqual(tm._boundaries[1].uniqueId, "B2")
+        tm.reset()
+        tm = TM("my test tm" )
+        internet = Boundary("Internet", uniqueId="B1")
+        athome = Boundary("athome", uniqueId="B2")
+        user = Actor("user", uniqueId="U1")
+        badactor = Actor("badactor", uniqueId="U2")
+        self.assertEqual(tm._elements[0].uniqueId, "B1")
+        self.assertEqual(tm._elements[1].uniqueId, "B2")
+        self.assertEqual(tm._elements[2].uniqueId, "U1")
+        self.assertEqual(tm._elements[3].uniqueId, "U2")
+        self.assertEqual(tm._actors[0].uniqueId, "U1")
+        self.assertEqual(tm._actors[1].uniqueId, "U2")
+        self.assertEqual(tm._boundaries[0].uniqueId, "B1")
+        self.assertEqual(tm._boundaries[1].uniqueId, "B2")
+
+
     def test_json_dumps(self):
         random.seed(0)
         dir_path = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
In my use case, I want to synchronize the findings with an external risk system. To be able to do so, I added these features -
1. Each element can be provided with a uniqueId. The idea is that these are specified when writing the model and thus static.
2. Findings will get a uniqueId which is a combination of the uniqueId and the findings's ID. In this way, these are also static and can be used as the primary key to the external risk system.
3. To make communication easier, the Element's uniqueId can be added to the name and thus become visible on the diagrams. This enables smoother dialog when talking about the output as talking about ABC becomes very precise.

I apologize upfront for these things -
- I only changed the pytm.py file to now. Any changes to README.md etc, I'll await your first feedback.
- I spend considerably time trying to get the value of the TM varStrings in the Element class. I could not find a way, so I added a global variable hack.
- I did not add any tests. Any advice on what tests I should add would be welcome.
 