### PR TITLE
Improve testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,8 +125,4 @@ tm_example.dot
 plantuml.jar
 tm/
 /sqldump
-/tests/output_current.json
-/tests/output_current.md
-/tests/1.txt
-/tests/0.txt
 /tests/.config.pytm

--- a/tests/run-unittests.ps1
+++ b/tests/run-unittests.ps1
@@ -1,0 +1,10 @@
+[CmdletBinding()]
+param (
+  [ValidateSet('always', 'never')]
+  [string] $pull = 'always'
+)
+
+# Run all tests using docker and a read-only file system so the docker image cannot impact the local files.
+
+$rootFolder = Split-Path $PSScriptRoot
+docker run --pull $pull --rm -v "${rootFolder}:/pwd:ro" python bash /pwd/tests/run-unittests.sh

--- a/tests/run-unittests.sh
+++ b/tests/run-unittests.sh
@@ -1,0 +1,6 @@
+# Script to prepare the environment and run the test. Is invoked by run-unittests.ps1
+
+cd /pwd && \
+pip install -r requirements-dev.txt && \
+pip install -r requirements.txt && \
+python3 -m unittest -v tests/test_pytmfunc.py

--- a/tests/test_pytmfunc.py
+++ b/tests/test_pytmfunc.py
@@ -3,6 +3,7 @@ import os
 import random
 import re
 import unittest
+import tempfile
 from contextlib import redirect_stdout
 
 from pytm import (
@@ -34,6 +35,7 @@ with open(
 ) as threat_file:
     threats = {t["SID"]: Threat(**t) for t in json.load(threat_file)}
 
+output_path=tempfile.gettempdir()
 
 class TestTM(unittest.TestCase):
     def test_seq(self):
@@ -325,7 +327,7 @@ class TestTM(unittest.TestCase):
         self.assertTrue(tm.check())
         output = json.dumps(tm, default=to_serializable, sort_keys=True, indent=4)
 
-        with open(os.path.join(dir_path, "output_current.json"), "w") as x:
+        with open(os.path.join(output_path, "output_current.json"), "w") as x:
             x.write(output)
 
         self.maxDiff = None
@@ -395,10 +397,10 @@ class TestTM(unittest.TestCase):
         self.assertTrue(tm.check())
         output = tm.report("docs/basic_template.md")
 
-        with open(os.path.join(dir_path, "output_current.md"), "w") as x:
+        with open(os.path.join(output_path, "output_current.md"), "w") as x:
             x.write(output)
 
-        with open(os.path.join(dir_path, "output_current.md"), "w") as x:
+        with open(os.path.join(output_path, "output_current.md"), "w") as x:
             x.write(output)
 
         self.maxDiff = None
@@ -433,7 +435,7 @@ class TestTM(unittest.TestCase):
 
         self.assertTrue(tm.check())
         output = tm.dfd(levels={0})
-        with open(os.path.join(dir_path, "0.txt"), "w") as x:
+        with open(os.path.join(output_path, "0.txt"), "w") as x:
             x.write(output)
         self.assertEqual(output, level_0)
 
@@ -452,7 +454,7 @@ class TestTM(unittest.TestCase):
 
         self.assertTrue(tm.check())
         output = tm.dfd(levels={1})
-        with open(os.path.join(dir_path, "1.txt"), "w") as x:
+        with open(os.path.join(output_path, "1.txt"), "w") as x:
             x.write(output)
         self.maxDiff = None
         self.assertEqual(output, level_1)

--- a/x.sh
+++ b/x.sh
@@ -1,7 +1,0 @@
-cd /pwd
-ls -l
-pip install -r requirements-dev.txt
-pip install -r requirements.txt
-pwd 
-python3 -m unittest -v tests/test_pytmfunc.py
-ls

--- a/x.sh
+++ b/x.sh
@@ -1,0 +1,7 @@
+cd /pwd
+ls -l
+pip install -r requirements-dev.txt
+pip install -r requirements.txt
+pwd 
+python3 -m unittest -v tests/test_pytmfunc.py
+ls


### PR DESCRIPTION
Move output from unit test to tempdir, allowing a read-only file system
Adding convenience run-unittests scripts for running tests in docker with read-only mount.
