### PR TITLE
Correct base image to use Python's Alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM python:3.11-rc-slim
+FROM python:3.11-rc-alpine
 
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
As it stands, the current image is slim, which is Debian-based. This minor correction will use the `-alpine` flavor of official Python docker images so the apk commands work.

Closes #196.