### PR TITLE
Corrected the Overide example

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,8 +279,8 @@ user_to_web = Dataflow(user, web, "User enters comments (*)", protocol="HTTP", d
 user_to_web.overrides = [
     Finding(
         # Overflow Buffers
-        id="INP02",
-        CVSS="9.3",
+        threat_id="INP02",
+        cvss="9.3",
         response="""**To Mitigate**: run a memory sanitizer to validate the binary""",
     )
 ]


### PR DESCRIPTION
The example of the override feature has not been kept up to date and it include an error when setting the CVSS.