### PR TITLE
Added Error handling for User errors

### DIFF
--- a/tests/test_private_func.py
+++ b/tests/test_private_func.py
@@ -12,6 +12,7 @@ from pytm.pytm import (
     Process,
     Server,
     Threat,
+    UIError,
 )
 
 
@@ -46,10 +47,10 @@ class TestAttributes(unittest.TestCase):
     def test_load_threats(self):
         tm = TM("TM")
         self.assertNotEqual(len(TM._threats), 0)
-        with self.assertRaises(FileNotFoundError):
+        with self.assertRaises(UIError):
             tm.threatsFile = "threats.json"
 
-        with self.assertRaises(FileNotFoundError):
+        with self.assertRaises(UIError):
             TM("TM", threatsFile="threats.json")
 
     def test_responses(self):


### PR DESCRIPTION
Some issues where raised where the users made an error when executing pytm on the shell.

It seems that the issue is that pytm is not returning a custom error but just a Python trace.

This commit add the UIError, which will be handled inside the process function.

UIError is a warpper arround another exception and adds a context description.

This commit only adds UIError for open calls in pytm, since these are obvious pitfalls for users.