### PR TITLE
fix 'make MODEL=bla' which is currently broken in master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,7 @@ MODEL?=tm
 
 libs := $(wildcard pytm/*.py) $(wildcard pytm/threatlib/*.json) $(wildcard pytm/images/*)
 
-all: clean docs/pytm/index.html 
-	$(MAKE) $(MODEL)
+all: clean docs/pytm/index.html $(MODEL)
 
 safe_filename:
 ifeq ($(suffix $(MODEL)), .py)


### PR DESCRIPTION
the ```make MODEL=bla``` functionality is currently broken in master:
```
$ cp tm.py tm2.py
$ make MODEL=tm2
rm -rf dist/* build/* tm2
make tm2
make: *** No rule to make target 'tm2'.  Stop.
make: *** [Makefile:18: all] Error 2
```

The patch fixes this.
