### PR TITLE
Added `prerequisites` and `likelihood` to Threat

### DIFF
--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -605,8 +605,10 @@ class Threat:
 to a boolean True or False""",
     )
     details = varString("")
+    likelihood = varString("")
     severity = varString("")
     mitigations = varString("")
+    prerequisites = varString("")
     example = varString("")
     references = varString("")
     target = ()
@@ -614,6 +616,7 @@ to a boolean True or False""",
     def __init__(self, **kwargs):
         self.id = kwargs["SID"]
         self.description = kwargs.get("description", "")
+        self.likelihood = kwargs.get("Likelihood Of Attack", "")
         self.condition = kwargs.get("condition", "True")
         target = kwargs.get("target", "Element")
         if not isinstance(target, str) and isinstance(target, Iterable):
@@ -624,6 +627,7 @@ to a boolean True or False""",
         self.details = kwargs.get("details", "")
         self.severity = kwargs.get("severity", "")
         self.mitigations = kwargs.get("mitigations", "")
+        self.prerequisites = kwargs.get("prerequisites", "")
         self.example = kwargs.get("example", "")
         self.references = kwargs.get("references", "")
 


### PR DESCRIPTION
In threats.json the two properties ("prerequisites", "Likelihood Of Attack") are defined, but are not used in the rest of pytm.

This commit adds the two properties to the Threat class, so they can be used by other parts of pytm.

For me this was relevant, since I started to experiment with a different format for threats mentioned in #237 .
And after exporting threat.json to a markdown format and back into threat.json these two fields where missing.