### PR TITLE
Replaced AC22 with AC23 and AC24

### DIFF
--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -818,9 +818,9 @@ with same properties, except name and notes""",
             raise UIError(
                 e, f"while trying to open the the threat file ({self.threatsFile})."
             )
-
-        for i in threats_json:
-            TM._threats.append(Threat(**i))
+        active_threats = (threat for threat in threats_json if "DEPRECATED" not in threat)
+        for threat in active_threats:
+            TM._threats.append(Threat(**threat))
 
     def resolve(self):
         finding_count = 0

--- a/pytm/threatlib/threats.json
+++ b/pytm/threatlib/threats.json
@@ -1559,6 +1559,22 @@
     "references": "https://cwe.mitre.org/data/definitions/311.html, https://cwe.mitre.org/data/definitions/312.html, https://cwe.mitre.org/data/definitions/916.html, https://cwe.mitre.org/data/definitions/653.html"
   },
   {
+    "SID": "AC22",
+    "DEPRECATED": "AC22 was replaced by AC23 and AC24. Forcing short lived credentials by rotating the credentials regularly is no longer recommended. It better to go for long living strong credentials, which can be easily replaced, when a disclosure has happend.",
+    "target": [
+      "Dataflow"
+    ],
+    "description": "Credentials Aging",
+    "details": "If no mechanism is in place for managing credentials (passwords and certificates) aging, users will have no incentive to update passwords or rotate certificates in a timely manner. Allowing password aging to occur unchecked or long certificate expiration dates can result in the possibility of diminished password integrity.",
+    "Likelihood Of Attack": "Medium",
+    "severity": "High",
+    "prerequisites": "",
+    "condition": "any(d.isCredentials for d in target.data) and target.sink.inScope and any(d.credentialsLife in (Lifetime.UNKNOWN, Lifetime.LONG, Lifetime.MANUAL, Lifetime.HARDCODED) for d in target.data)",
+    "mitigations": "All passwords and other credentials should have a relatively short expiration date with a possibility to be revoked immediately under special circumstances.",
+    "example": "",
+    "references": "https://cwe.mitre.org/data/definitions/262.html, https://cwe.mitre.org/data/definitions/263.html, https://cwe.mitre.org/data/definitions/798.html"
+  },
+  {
     "SID": "AC23",
     "target": [
       "Dataflow"

--- a/pytm/threatlib/threats.json
+++ b/pytm/threatlib/threats.json
@@ -1559,18 +1559,33 @@
     "references": "https://cwe.mitre.org/data/definitions/311.html, https://cwe.mitre.org/data/definitions/312.html, https://cwe.mitre.org/data/definitions/916.html, https://cwe.mitre.org/data/definitions/653.html"
   },
   {
-    "SID": "AC22",
+    "SID": "AC23",
     "target": [
       "Dataflow"
     ],
-    "description": "Credentials Aging",
-    "details": "If no mechanism is in place for managing credentials (passwords and certificates) aging, users will have no incentive to update passwords or rotate certificates in a timely manner. Allowing password aging to occur unchecked or long certificate expiration dates can result in the possibility of diminished password integrity.",
+    "description": "Credentials Disclosure",
+    "details": "If credentials (passwords or certificates) have a long lifetime their disclosure can have severe consequences, if the credentials cannot quickly be revoked and/or rotated.",
     "Likelihood Of Attack": "Medium",
     "severity": "High",
     "prerequisites": "",
-    "condition": "any(d.isCredentials for d in target.data) and target.sink.inScope and any(d.credentialsLife in (Lifetime.UNKNOWN, Lifetime.LONG, Lifetime.MANUAL, Lifetime.HARDCODED) for d in target.data)",
-    "mitigations": "All passwords and other credentials should have a relatively short expiration date with a possibility to be revoked immediately under special circumstances.",
+    "condition": "any(d.isCredentials for d in target.data) and target.sink.inScope and any(d.credentialsLife in (Lifetime.UNKNOWN, Lifetime.LONG, Lifetime.MANUAL) for d in target.data)",
+    "mitigations": "Long living credentials need to have high entropy and length to be future proof, especially if it is unknwon how long these credentials will be used. Further should there be a mechanism to revoke the credentials immediately if a disclosure is suspected. To detect disclosure of the credentials their use should be monitored for suspicions activity.",
     "example": "",
-    "references": "https://cwe.mitre.org/data/definitions/262.html, https://cwe.mitre.org/data/definitions/263.html, https://cwe.mitre.org/data/definitions/798.html"
+    "references": "https://pages.nist.gov/800-63-3/sp800-63b.html#sec6"
+  },
+  {
+    "SID": "AC24",
+    "target": [
+      "Dataflow"
+    ],
+    "description": "Use of hardcoded credentials",
+    "details": "Hardcoded credentials (password or certificates) cannot be changed and if these credentials are dislcosed they can be used by attackers to bypass the authentication mechanism.",
+    "Likelihood Of Attack": "High",
+    "severity": "Very High",
+    "prerequisites": "",
+    "condition": "any(d.isCredentials for d in target.data) and target.sink.inScope and any(d.credentialsLife == Lifetime.HARDCODED for d in target.data)",
+    "mitigations": "Avoid hardcoded credentials. If you have to use hardcoded credentials make is possible to change the credentials or to deactivate them. A typical design is to use a \"first login\"-mode which forces the user to create new credentials, on the first login. If the credentials cannot be changed the sole actions in prodcution for the defender is to deactivate/remove the effected product.",
+    "example": "",
+    "references": "https://cwe.mitre.org/data/definitions/798.html, https://cwe.mitre.org/data/definitions/259.html, https://cwe.mitre.org/data/definitions/321.html"
   }
 ]

--- a/tests/test_pytmfunc.py
+++ b/tests/test_pytmfunc.py
@@ -1462,7 +1462,19 @@ class Testpytm(unittest.TestCase):
         threat = threats["AC21"]
         self.assertTrue(threat.apply(process1))
 
-    def test_AC22(self):
+    def test_AC23(self):
+        user = Actor("User")
+        web = Server("Web Server")
+        user_to_web = Dataflow(user, web, "User enters comments (*)")
+        user_to_web.data = Data(
+            "password", isCredentials=True, credentialsLife=Lifetime.LONG
+        )
+        user_to_web.protocol = "HTTPS"
+        user_to_web.controls.isEncrypted = True
+        threat = threats["AC23"]
+        self.assertTrue(threat.apply(user_to_web))
+
+    def test_AC24(self):
         user = Actor("User")
         web = Server("Web Server")
         user_to_web = Dataflow(user, web, "User enters comments (*)")
@@ -1471,7 +1483,7 @@ class Testpytm(unittest.TestCase):
         )
         user_to_web.protocol = "HTTPS"
         user_to_web.controls.isEncrypted = True
-        threat = threats["AC22"]
+        threat = threats["AC24"]
         self.assertTrue(threat.apply(user_to_web))
 
     def test_DR01(self):


### PR DESCRIPTION
As mentioned in #239 AC22 Credential Aging review the threat AC22 Credential Aging was not helpful.

This commit replaces AC22 with two new threats AC23 Credential Disclosure and AC24 Hardcoded Credentials.

AC23 checks if the lifetime of the credentials is LONG, MANAUL, or UNKNOWN.
Currently there is no way to resolve this threat by changing the model, besides setting the a different lifetime.

AC24 warns against the use of hardcoded credentials.