### PR TITLE
Add Assumption to Elements

### DIFF
--- a/docs/advanced_template.md
+++ b/docs/advanced_template.md
@@ -158,3 +158,28 @@ Finding Count|{{item:call:getFindingCount}}|
 }}
 }}
 }
+
+{tm.excluded_findings:if:
+# Excluded Threats
+}
+
+{tm.excluded_findings:repeat:
+<details>
+  <summary>  {{item.id}}  --  {{item.threat_id}}   --   {{item.description}}</summary>
+  <p>**{{item.threat_id}}** was excluded for **{{item.target}}** because of the assumption: "{{item.assumption.name}}
+"</p>
+  {{item.assumption.description:if:
+    <h6> Assumption description </h6>
+    <p> {{item.assumption.description}} </p>  
+  }}
+
+  <h6> Targeted Element </h6>
+  <p> {{item.target}} </p>
+  <h6> Severity </h6>
+  <p>{{item.severity}}</p>
+  <h6>Example Instances</h6>
+  <p>{{item.example}}</p>
+  <h6>References</h6>
+  <p>{{item.references}}</p>
+</details>
+}

--- a/docs/pytm/index.html
+++ b/docs/pytm/index.html
@@ -29,9 +29,9 @@
 <pre><code class="python">__all__ = [
     &#34;Action&#34;,
     &#34;Actor&#34;,
+    &#34;Assumption&#34;,
     &#34;Boundary&#34;,
     &#34;Classification&#34;,
-    &#34;Controls&#34;,
     &#34;TLSVersion&#34;,
     &#34;Data&#34;,
     &#34;Dataflow&#34;,
@@ -58,9 +58,9 @@ from .pytm import (
     TM,
     Action,
     Actor,
+    Assumption,
     Boundary,
     Classification,
-    Controls,
     Data,
     Dataflow,
     Datastore,
@@ -98,6 +98,13 @@ __pdoc__ = pdoc_overrides()</code></pre>
 </details>
 </section>
 <section>
+<h2 class="section-title" id="header-submodules">Sub-modules</h2>
+<dl>
+<dt><code class="name"><a title="pytm.report_util" href="report_util.html">pytm.report_util</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
 </section>
 <section>
 </section>
@@ -198,19 +205,7 @@ __pdoc__ = pdoc_overrides()</code></pre>
     data = varData([], doc=&#34;pytm.Data object(s) in outgoing data flows&#34;)
     inputs = varElements([], doc=&#34;incoming Dataflows&#34;)
     outputs = varElements([], doc=&#34;outgoing Dataflows&#34;)
-    authenticatesDestination = varBool(
-        False,
-        doc=&#34;&#34;&#34;Verifies the identity of the destination,
-for example by verifying the authenticity of a digital certificate.&#34;&#34;&#34;,
-    )
-    checksDestinationRevocation = varBool(
-        False,
-        doc=&#34;&#34;&#34;Correctly checks the revocation status
-of credentials used to authenticate the destination&#34;&#34;&#34;,
-    )
     isAdmin = varBool(False)
-    # should not be settable, but accessible
-    providesIntegrity = False
 
     def __init__(self, name, **kwargs):
         super().__init__(name, **kwargs)
@@ -220,49 +215,8 @@ of credentials used to authenticate the destination&#34;&#34;&#34;,
 <ul class="hlist">
 <li>pytm.pytm.Element</li>
 </ul>
-<h3>Class variables</h3>
-<dl>
-<dt id="pytm.Actor.providesIntegrity"><code class="name">var <span class="ident">providesIntegrity</span></code></dt>
-<dd>
-<div class="desc"></div>
-</dd>
-</dl>
 <h3>Instance variables</h3>
 <dl>
-<dt id="pytm.Actor.authenticatesDestination"><code class="name">var <span class="ident">authenticatesDestination</span></code></dt>
-<dd>
-<div class="desc"><p>Verifies the identity of the destination,
-for example by verifying the authenticity of a digital certificate.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Actor.checksDestinationRevocation"><code class="name">var <span class="ident">checksDestinationRevocation</span></code></dt>
-<dd>
-<div class="desc"><p>Correctly checks the revocation status
-of credentials used to authenticate the destination</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
 <dt id="pytm.Actor.data"><code class="name">var <span class="ident">data</span></code></dt>
 <dd>
 <div class="desc"><p>pytm.Data object(s) in outgoing data flows</p></div>
@@ -361,6 +315,83 @@ of credentials used to authenticate the destination</p></div>
 </dd>
 </dl>
 </dd>
+<dt id="pytm.Assumption"><code class="flex name class">
+<span>class <span class="ident">Assumption</span></span>
+<span>(</span><span>name, **kwargs)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Assumption implemented by/on an Element.
+Used to exclude threats on a per-element basis.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class Assumption:
+    &#34;&#34;&#34;
+    Assumption implemented by/on an Element.
+    Used to exclude threats on a per-element basis.
+    &#34;&#34;&#34;
+    name = varString(&#34;&#34;, required=True)
+    exclude = varStrings([], doc=&#34;A list of threat SIDs to exclude for this assumption. For example: INP01&#34;)
+    description = varString(&#34;&#34;, doc=&#34;An additional description of the assumption&#34;)
+
+    def __init__(self, name, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        self.name = name</code></pre>
+</details>
+<h3>Instance variables</h3>
+<dl>
+<dt id="pytm.Assumption.description"><code class="name">var <span class="ident">description</span></code></dt>
+<dd>
+<div class="desc"><p>An additional description of the assumption</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def __get__(self, instance, owner):
+    # when x.d is called we get here
+    # instance = x
+    # owner = type(x)
+    if instance is None:
+        return self
+    return self.data.get(instance, self.default)</code></pre>
+</details>
+</dd>
+<dt id="pytm.Assumption.exclude"><code class="name">var <span class="ident">exclude</span></code></dt>
+<dd>
+<div class="desc"><p>A list of threat SIDs to exclude for this assumption. For example: INP01</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def __get__(self, instance, owner):
+    # when x.d is called we get here
+    # instance = x
+    # owner = type(x)
+    if instance is None:
+        return self
+    return self.data.get(instance, self.default)</code></pre>
+</details>
+</dd>
+<dt id="pytm.Assumption.name"><code class="name">var <span class="ident">name</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def __get__(self, instance, owner):
+    # when x.d is called we get here
+    # instance = x
+    # owner = type(x)
+    if instance is None:
+        return self
+    return self.data.get(instance, self.default)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
 <dt id="pytm.Boundary"><code class="flex name class">
 <span>class <span class="ident">Boundary</span></span>
 <span>(</span><span>name, **kwargs)</span>
@@ -383,7 +414,7 @@ of credentials used to authenticate the destination</p></div>
         return &#34;&#34;&#34;subgraph cluster_{uniq_name} {{
     graph [
         fontsize = 10;
-        fontcolor = {color};
+        fontcolor = black;
         style = dashed;
         color = {color};
         label = &lt;&lt;i&gt;{label}&lt;/i&gt;&gt;;
@@ -399,23 +430,25 @@ of credentials used to authenticate the destination</p></div>
 
         self._is_drawn = True
 
-        logger.debug(&#34;Now drawing boundary &#34; + self.name)
         edges = []
         for e in TM._elements:
             if e.inBoundary != self or e._is_drawn:
                 continue
             # The content to draw can include Boundary objects
-            logger.debug(&#34;Now drawing content {}&#34;.format(e.name))
             edges.append(e.dfd(**kwargs))
+
         return self._dfd_template().format(
             uniq_name=self._uniq_name(),
             label=self._label(),
-            color=self._color(),
+            color=self._color(**kwargs),
             edges=indent(&#34;\n&#34;.join(edges), &#34;    &#34;),
         )
 
-    def _color(self):
-        return &#34;firebrick2&#34;
+    def _color(self, **kwargs):
+        if kwargs.get(&#34;colormap&#34;, False):
+            return &#34;black&#34;
+        else:
+            return &#34;firebrick2&#34;
 
     def parents(self):
         result = []
@@ -499,822 +532,6 @@ of credentials used to authenticate the destination</p></div>
 <dt id="pytm.Classification.UNKNOWN"><code class="name">var <span class="ident">UNKNOWN</span></code></dt>
 <dd>
 <div class="desc"></div>
-</dd>
-</dl>
-</dd>
-<dt id="pytm.Controls"><code class="flex name class">
-<span>class <span class="ident">Controls</span></span>
-</code></dt>
-<dd>
-<div class="desc"><p>Controls implemented by/on and Element</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">class Controls:
-&#34;&#34;&#34;Controls implemented by/on and Element&#34;&#34;&#34;
-
-authenticatesDestination = varBool(
-    False,
-    doc=&#34;&#34;&#34;Verifies the identity of the destination,
-for example by verifying the authenticity of a digital certificate.&#34;&#34;&#34;,
-)
-authenticatesSource = varBool(False)
-authenticationScheme = varString(&#34;&#34;)
-authorizesSource = varBool(False)
-checksDestinationRevocation = varBool(
-    False,
-    doc=&#34;&#34;&#34;Correctly checks the revocation status
-of credentials used to authenticate the destination&#34;&#34;&#34;,
-)
-checksInputBounds = varBool(False)
-definesConnectionTimeout = varBool(False)
-disablesDTD = varBool(False)
-disablesiFrames = varBool(False)
-encodesHeaders = varBool(False)
-encodesOutput = varBool(False)
-encryptsCookies = varBool(False)
-encryptsSessionData = varBool(False)
-handlesCrashes = varBool(False)
-handlesInterruptions = varBool(False)
-handlesResourceConsumption = varBool(False)
-hasAccessControl = varBool(False)
-implementsAuthenticationScheme = varBool(False)
-implementsCSRFToken = varBool(False)
-implementsNonce = varBool(
-    False,
-    doc=&#34;&#34;&#34;Nonce is an arbitrary number
-that can be used just once in a cryptographic communication.
-It is often a random or pseudo-random number issued in an authentication protocol
-to ensure that old communications cannot be reused in replay attacks.
-They can also be useful as initialization vectors and in cryptographic
-hash functions.&#34;&#34;&#34;,
-)
-implementsPOLP = varBool(
-    False,
-    doc=&#34;&#34;&#34;The principle of least privilege (PoLP),
-also known as the principle of minimal privilege or the principle of least authority,
-requires that in a particular abstraction layer of a computing environment,
-every module (such as a process, a user, or a program, depending on the subject)
-must be able to access only the information and resources
-that are necessary for its legitimate purpose.&#34;&#34;&#34;,
-)
-implementsServerSideValidation = varBool(False)
-implementsStrictHTTPValidation = varBool(False)
-invokesScriptFilters = varBool(False)
-isEncrypted = varBool(False, doc=&#34;Requires incoming data flow to be encrypted&#34;)
-isEncryptedAtRest = varBool(False, doc=&#34;Stored data is encrypted at rest&#34;)
-isHardened = varBool(False)
-isResilient = varBool(False)
-providesConfidentiality = varBool(False)
-providesIntegrity = varBool(False)
-sanitizesInput = varBool(False)
-tracksExecutionFlow = varBool(False)
-usesCodeSigning = varBool(False)
-usesEncryptionAlgorithm = varString(&#34;&#34;)
-usesMFA = varBool(
-    False,
-    doc=&#34;&#34;&#34;Multi-factor authentication is an authentication method
-in which a computer user is granted access only after successfully presenting two
-or more pieces of evidence (or factors) to an authentication mechanism: knowledge
-(something the user and only the user knows), possession (something the user
-and only the user has), and inherence (something the user and only the user is).&#34;&#34;&#34;,
-)
-usesParameterizedInput = varBool(False)
-usesSecureFunctions = varBool(False)
-usesStrongSessionIdentifiers = varBool(False)
-usesVPN = varBool(False)
-validatesContentType = varBool(False)
-validatesHeaders = varBool(False)
-validatesInput = varBool(False)
-verifySessionIdentifiers = varBool(False)
-
-def _attr_values(self):
-    klass = self.__class__
-    result = {}
-    for i in dir(klass):
-        if i.startswith(&#34;_&#34;) or callable(getattr(klass, i)):
-            continue
-        attr = getattr(klass, i, {})
-        if isinstance(attr, var):
-            value = attr.data.get(self, attr.default)
-        else:
-            value = getattr(self, i)
-        result[i] = value
-    return result
-
-
-def _safeset(self, attr, value):
-    try:
-        setattr(self, attr, value)
-    except ValueError:
-        pass</code></pre>
-</details>
-<h3>Instance variables</h3>
-<dl>
-<dt id="pytm.Controls.authenticatesDestination"><code class="name">var <span class="ident">authenticatesDestination</span></code></dt>
-<dd>
-<div class="desc"><p>Verifies the identity of the destination,
-for example by verifying the authenticity of a digital certificate.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.authenticatesSource"><code class="name">var <span class="ident">authenticatesSource</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.authenticationScheme"><code class="name">var <span class="ident">authenticationScheme</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.authorizesSource"><code class="name">var <span class="ident">authorizesSource</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.checksDestinationRevocation"><code class="name">var <span class="ident">checksDestinationRevocation</span></code></dt>
-<dd>
-<div class="desc"><p>Correctly checks the revocation status
-of credentials used to authenticate the destination</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.checksInputBounds"><code class="name">var <span class="ident">checksInputBounds</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.definesConnectionTimeout"><code class="name">var <span class="ident">definesConnectionTimeout</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.disablesDTD"><code class="name">var <span class="ident">disablesDTD</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.disablesiFrames"><code class="name">var <span class="ident">disablesiFrames</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.encodesHeaders"><code class="name">var <span class="ident">encodesHeaders</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.encodesOutput"><code class="name">var <span class="ident">encodesOutput</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.encryptsCookies"><code class="name">var <span class="ident">encryptsCookies</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.encryptsSessionData"><code class="name">var <span class="ident">encryptsSessionData</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.handlesCrashes"><code class="name">var <span class="ident">handlesCrashes</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.handlesInterruptions"><code class="name">var <span class="ident">handlesInterruptions</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.handlesResourceConsumption"><code class="name">var <span class="ident">handlesResourceConsumption</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.hasAccessControl"><code class="name">var <span class="ident">hasAccessControl</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.implementsAuthenticationScheme"><code class="name">var <span class="ident">implementsAuthenticationScheme</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.implementsCSRFToken"><code class="name">var <span class="ident">implementsCSRFToken</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.implementsNonce"><code class="name">var <span class="ident">implementsNonce</span></code></dt>
-<dd>
-<div class="desc"><p>Nonce is an arbitrary number
-that can be used just once in a cryptographic communication.
-It is often a random or pseudo-random number issued in an authentication protocol
-to ensure that old communications cannot be reused in replay attacks.
-They can also be useful as initialization vectors and in cryptographic
-hash functions.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.implementsPOLP"><code class="name">var <span class="ident">implementsPOLP</span></code></dt>
-<dd>
-<div class="desc"><p>The principle of least privilege (PoLP),
-also known as the principle of minimal privilege or the principle of least authority,
-requires that in a particular abstraction layer of a computing environment,
-every module (such as a process, a user, or a program, depending on the subject)
-must be able to access only the information and resources
-that are necessary for its legitimate purpose.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.implementsServerSideValidation"><code class="name">var <span class="ident">implementsServerSideValidation</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.implementsStrictHTTPValidation"><code class="name">var <span class="ident">implementsStrictHTTPValidation</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.invokesScriptFilters"><code class="name">var <span class="ident">invokesScriptFilters</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.isEncrypted"><code class="name">var <span class="ident">isEncrypted</span></code></dt>
-<dd>
-<div class="desc"><p>Requires incoming data flow to be encrypted</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.isEncryptedAtRest"><code class="name">var <span class="ident">isEncryptedAtRest</span></code></dt>
-<dd>
-<div class="desc"><p>Stored data is encrypted at rest</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.isHardened"><code class="name">var <span class="ident">isHardened</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.isResilient"><code class="name">var <span class="ident">isResilient</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.providesConfidentiality"><code class="name">var <span class="ident">providesConfidentiality</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.providesIntegrity"><code class="name">var <span class="ident">providesIntegrity</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.sanitizesInput"><code class="name">var <span class="ident">sanitizesInput</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.tracksExecutionFlow"><code class="name">var <span class="ident">tracksExecutionFlow</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.usesCodeSigning"><code class="name">var <span class="ident">usesCodeSigning</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.usesEncryptionAlgorithm"><code class="name">var <span class="ident">usesEncryptionAlgorithm</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.usesMFA"><code class="name">var <span class="ident">usesMFA</span></code></dt>
-<dd>
-<div class="desc"><p>Multi-factor authentication is an authentication method
-in which a computer user is granted access only after successfully presenting two
-or more pieces of evidence (or factors) to an authentication mechanism: knowledge
-(something the user and only the user knows), possession (something the user
-and only the user has), and inherence (something the user and only the user is).</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.usesParameterizedInput"><code class="name">var <span class="ident">usesParameterizedInput</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.usesSecureFunctions"><code class="name">var <span class="ident">usesSecureFunctions</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.usesStrongSessionIdentifiers"><code class="name">var <span class="ident">usesStrongSessionIdentifiers</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.usesVPN"><code class="name">var <span class="ident">usesVPN</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.validatesContentType"><code class="name">var <span class="ident">validatesContentType</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.validatesHeaders"><code class="name">var <span class="ident">validatesHeaders</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.validatesInput"><code class="name">var <span class="ident">validatesInput</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Controls.verifySessionIdentifiers"><code class="name">var <span class="ident">verifySessionIdentifiers</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-# when x.d is called we get here
-# instance = x
-# owner = type(x)
-if instance is None:
-    return self
-return self.data.get(instance, self.default)</code></pre>
-</details>
 </dd>
 </dl>
 </dd>
@@ -1624,7 +841,6 @@ If only derivative data is stored (a hash) it can be set to False.</p></div>
     responseTo = varElement(None, doc=&#34;Is a response to this data flow&#34;)
     srcPort = varInt(-1, doc=&#34;Source TCP port&#34;)
     dstPort = varInt(-1, doc=&#34;Destination TCP port&#34;)
-    isEncrypted = varBool(False, doc=&#34;Is the data encrypted&#34;)
     tlsVersion = varTLSVersion(
         TLSVersion.NONE,
         required=True,
@@ -1632,24 +848,12 @@ If only derivative data is stored (a hash) it can be set to False.</p></div>
     )
     protocol = varString(&#34;&#34;, doc=&#34;Protocol used in this data flow&#34;)
     data = varData([], doc=&#34;pytm.Data object(s) in incoming data flows&#34;)
-    authenticatesDestination = varBool(
-        False,
-        doc=&#34;&#34;&#34;Verifies the identity of the destination,
-for example by verifying the authenticity of a digital certificate.&#34;&#34;&#34;,
-    )
-    checksDestinationRevocation = varBool(
-        False,
-        doc=&#34;&#34;&#34;Correctly checks the revocation status
-of credentials used to authenticate the destination&#34;&#34;&#34;,
-    )
-    authenticatedWith = varBool(False)
     order = varInt(-1, doc=&#34;Number of this data flow in the threat model&#34;)
-    implementsAuthenticationScheme = varBool(False)
     implementsCommunicationProtocol = varBool(False)
     note = varString(&#34;&#34;)
     usesVPN = varBool(False)
-    authorizesSource = varBool(False)
     usesSessionTokens = varBool(False)
+    severity = 0
 
     def __init__(self, source, sink, name, **kwargs):
         self.source = source
@@ -1682,6 +886,11 @@ of credentials used to authenticate the destination&#34;&#34;&#34;,
         ):
             return &#34;&#34;
 
+        color = self._color()
+
+        if kwargs.get(&#34;colormap&#34;, False):
+            color = sev_to_color(self.severity)
+
         direction = &#34;forward&#34;
         label = self._label()
         if mergeResponses and self.response is not None:
@@ -1693,7 +902,7 @@ of credentials used to authenticate the destination&#34;&#34;&#34;,
             sink=self.sink._uniq_name(),
             direction=direction,
             label=label,
-            color=self._color(),
+            color=color,
         )
 
     def hasDataLeaks(self):
@@ -1708,74 +917,15 @@ of credentials used to authenticate the destination&#34;&#34;&#34;,
 <ul class="hlist">
 <li>pytm.pytm.Element</li>
 </ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="pytm.Dataflow.severity"><code class="name">var <span class="ident">severity</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
 <h3>Instance variables</h3>
 <dl>
-<dt id="pytm.Dataflow.authenticatedWith"><code class="name">var <span class="ident">authenticatedWith</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Dataflow.authenticatesDestination"><code class="name">var <span class="ident">authenticatesDestination</span></code></dt>
-<dd>
-<div class="desc"><p>Verifies the identity of the destination,
-for example by verifying the authenticity of a digital certificate.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Dataflow.authorizesSource"><code class="name">var <span class="ident">authorizesSource</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Dataflow.checksDestinationRevocation"><code class="name">var <span class="ident">checksDestinationRevocation</span></code></dt>
-<dd>
-<div class="desc"><p>Correctly checks the revocation status
-of credentials used to authenticate the destination</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
 <dt id="pytm.Dataflow.data"><code class="name">var <span class="ident">data</span></code></dt>
 <dd>
 <div class="desc"><p>pytm.Data object(s) in incoming data flows</p></div>
@@ -1808,41 +958,9 @@ of credentials used to authenticate the destination</p></div>
     return self.data.get(instance, self.default)</code></pre>
 </details>
 </dd>
-<dt id="pytm.Dataflow.implementsAuthenticationScheme"><code class="name">var <span class="ident">implementsAuthenticationScheme</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
 <dt id="pytm.Dataflow.implementsCommunicationProtocol"><code class="name">var <span class="ident">implementsCommunicationProtocol</span></code></dt>
 <dd>
 <div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Dataflow.isEncrypted"><code class="name">var <span class="ident">isEncrypted</span></code></dt>
-<dd>
-<div class="desc"><p>Is the data encrypted</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -2108,24 +1226,8 @@ is any information relating to an identifiable person.&#34;&#34;&#34;,
     )
     storesSensitiveData = varBool(False)
     isSQL = varBool(True)
-    providesConfidentiality = varBool(False)
-    providesIntegrity = varBool(False)
     isShared = varBool(False)
     hasWriteAccess = varBool(False)
-    handlesResourceConsumption = varBool(False)
-    isResilient = varBool(False)
-    handlesInterruptions = varBool(False)
-    usesEncryptionAlgorithm = varString(&#34;&#34;)
-    implementsPOLP = varBool(
-        False,
-        doc=&#34;&#34;&#34;The principle of least privilege (PoLP),
-also known as the principle of minimal privilege or the principle of least authority,
-requires that in a particular abstraction layer of a computing environment,
-every module (such as a process, a user, or a program, depending on the subject)
-must be able to access only the information and resources
-that are necessary for its legitimate purpose.&#34;&#34;&#34;,
-    )
-    isEncryptedAtRest = varBool(False, doc=&#34;Stored data is encrypted at rest&#34;)
     type = varDatastoreType(
         DatastoreType.UNKNOWN,
         doc=&#34;&#34;&#34;The  type of Datastore, values may be one of:
@@ -2133,7 +1235,7 @@ that are necessary for its legitimate purpose.&#34;&#34;&#34;,
 * FILE_SYSTEM - files on a file system
 * SQL - A SQL Database
 * LDAP - An LDAP Server
-* AWS_S3 - An S3 Bucket within AWS&#34;&#34;&#34;
+* AWS_S3 - An S3 Bucket within AWS&#34;&#34;&#34;,
     )
 
     def __init__(self, name, **kwargs):
@@ -2146,7 +1248,7 @@ that are necessary for its legitimate purpose.&#34;&#34;&#34;,
     image = &#34;{image}&#34;;
     imagescale = true;
     color = {color};
-    fontcolor = {color};
+    fontcolor = black;
     xlabel = &#34;{label}&#34;;
     label = &#34;&#34;;
 ]
@@ -2162,12 +1264,21 @@ that are necessary for its legitimate purpose.&#34;&#34;&#34;,
         if levels and not levels &amp; self.levels:
             return &#34;&#34;
 
+        color = self._color()
+        color_file = &#34;black&#34;
+
+        if kwargs.get(&#34;colormap&#34;, False):
+            color = sev_to_color(self.severity)
+            color_file = color.split(&#34;;&#34;)[0]
+
         return self._dfd_template().format(
             uniq_name=self._uniq_name(),
             label=self._label(),
-            color=self._color(),
+            color=color,
             shape=self._shape(),
-            image=os.path.join(os.path.dirname(__file__), &#34;images&#34;, &#34;datastore.png&#34;),
+            image=os.path.join(
+                os.path.dirname(__file__), &#34;images&#34;, f&#34;datastore_{color_file}.png&#34;
+            ),
         )</code></pre>
 </details>
 <h3>Ancestors</h3>
@@ -2177,92 +1288,7 @@ that are necessary for its legitimate purpose.&#34;&#34;&#34;,
 </ul>
 <h3>Instance variables</h3>
 <dl>
-<dt id="pytm.Datastore.handlesInterruptions"><code class="name">var <span class="ident">handlesInterruptions</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Datastore.handlesResourceConsumption"><code class="name">var <span class="ident">handlesResourceConsumption</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
 <dt id="pytm.Datastore.hasWriteAccess"><code class="name">var <span class="ident">hasWriteAccess</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Datastore.implementsPOLP"><code class="name">var <span class="ident">implementsPOLP</span></code></dt>
-<dd>
-<div class="desc"><p>The principle of least privilege (PoLP),
-also known as the principle of minimal privilege or the principle of least authority,
-requires that in a particular abstraction layer of a computing environment,
-every module (such as a process, a user, or a program, depending on the subject)
-must be able to access only the information and resources
-that are necessary for its legitimate purpose.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Datastore.isEncryptedAtRest"><code class="name">var <span class="ident">isEncryptedAtRest</span></code></dt>
-<dd>
-<div class="desc"><p>Stored data is encrypted at rest</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Datastore.isResilient"><code class="name">var <span class="ident">isResilient</span></code></dt>
 <dd>
 <div class="desc"></div>
 <details class="source">
@@ -2311,38 +1337,6 @@ that are necessary for its legitimate purpose.</p></div>
 </details>
 </dd>
 <dt id="pytm.Datastore.onRDS"><code class="name">var <span class="ident">onRDS</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Datastore.providesConfidentiality"><code class="name">var <span class="ident">providesConfidentiality</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Datastore.providesIntegrity"><code class="name">var <span class="ident">providesIntegrity</span></code></dt>
 <dd>
 <div class="desc"></div>
 <details class="source">
@@ -2407,22 +1401,6 @@ is any information relating to an identifiable person.</p></div>
     return self.data.get(instance, self.default)</code></pre>
 </details>
 </dd>
-<dt id="pytm.Datastore.usesEncryptionAlgorithm"><code class="name">var <span class="ident">usesEncryptionAlgorithm</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
 <dt id="pytm.Datastore.type"><code class="name">var <span class="ident">type</span></code></dt>
 <dd>
 <div class="desc"><p>The
@@ -2444,8 +1422,6 @@ type of Datastore, values may be one of:
         return self
     return self.data.get(instance, self.default)</code></pre>
 </details>
-</dd>
-</dl>
 </dd>
 </dl>
 </dd>
@@ -2546,6 +1522,10 @@ type of Datastore, values may be one of:
         doc=&#34;&#34;&#34;Overrides to findings, allowing to set
 a custom response, CVSS score or override other attributes.&#34;&#34;&#34;,
     )
+    assumptions = varAssumptions(
+        [],
+        doc=&#34;Assumptions about the element. These optionally allow to exclude threats with the given SIDs.&#34;,
+    )
     levels = varInts({0}, doc=&#34;List of levels (0, 1, 2, ...) to be drawn in the model.&#34;)
     sourceFiles = varStrings(
         [],
@@ -2553,6 +1533,7 @@ a custom response, CVSS score or override other attributes.&#34;&#34;&#34;,
         doc=&#34;Location of the source code that describes this element relative to the directory of the model script.&#34;,
     )
     controls = varControls(None)
+    severity = 0
 
     def __init__(self, name, **kwargs):
         for key, value in kwargs.items():
@@ -2584,7 +1565,7 @@ a custom response, CVSS score or override other attributes.&#34;&#34;&#34;,
         return &#34;&#34;&#34;{uniq_name} [
     shape = {shape};
     color = {color};
-    fontcolor = {color};
+    fontcolor = black;
     label = &#34;{label}&#34;;
     margin = 0.02;
 ]
@@ -2597,10 +1578,14 @@ a custom response, CVSS score or override other attributes.&#34;&#34;&#34;,
         if levels and not levels &amp; self.levels:
             return &#34;&#34;
 
+        color = self._color()
+        if kwargs.get(&#34;colormap&#34;, False):
+            color = sev_to_color(self.severity)
+
         return self._dfd_template().format(
             uniq_name=self._uniq_name(),
             label=self._label(),
-            color=self._color(),
+            color=color,
             shape=self._shape(),
         )
 
@@ -2692,7 +1677,24 @@ a custom response, CVSS score or override other attributes.&#34;&#34;&#34;,
         return result
 
     def checkTLSVersion(self, flows):
-        return any(f.tlsVersion &lt; self.minTLSVersion for f in flows)</code></pre>
+        return any(f.tlsVersion &lt; self.minTLSVersion for f in flows)
+
+    def _set_severity(self, sev):
+        sevs = {
+            &#34;very high&#34;: 5,
+            &#34;high&#34;: 4,
+            &#34;medium&#34;: 3,
+            &#34;low&#34;: 2,
+            &#34;very low&#34;: 1,
+            &#34;info&#34;: 0,
+        }
+
+        if sev.lower() not in sevs.keys():
+            return
+
+        if self.severity &lt; sevs[sev.lower()]:
+            self.severity = sevs[sev.lower()]
+        return</code></pre>
 </details>
 <h3>Subclasses</h3>
 <ul class="hlist">
@@ -2701,8 +1703,31 @@ a custom response, CVSS score or override other attributes.&#34;&#34;&#34;,
 <li>pytm.pytm.Boundary</li>
 <li>pytm.pytm.Dataflow</li>
 </ul>
+<h3>Class variables</h3>
+<dl>
+<dt id="pytm.Element.severity"><code class="name">var <span class="ident">severity</span></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
 <h3>Instance variables</h3>
 <dl>
+<dt id="pytm.Element.assumptions"><code class="name">var <span class="ident">assumptions</span></code></dt>
+<dd>
+<div class="desc"><p>Assumptions about the element. These optionally allow to exclude threats with the given SIDs.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def __get__(self, instance, owner):
+    # when x.d is called we get here
+    # instance = x
+    # owner = type(x)
+    if instance is None:
+        return self
+    return self.data.get(instance, self.default)</code></pre>
+</details>
+</dd>
 <dt id="pytm.Element.controls"><code class="name">var <span class="ident">controls</span></code></dt>
 <dd>
 <div class="desc"></div>
@@ -3080,12 +2105,13 @@ and a description of the finding</p></div>
     threat_id = varString(&#34;&#34;, required=True, doc=&#34;Threat ID&#34;)
     references = varString(&#34;&#34;, required=True, doc=&#34;Threat references&#34;)
     condition = varString(&#34;&#34;, required=True, doc=&#34;Threat condition&#34;)
+    assumption = varAssumption(None, required=False, doc=&#34;The assumption, that caused this finding to be excluded&#34;)
     response = varString(
         &#34;&#34;,
         required=False,
         doc=&#34;&#34;&#34;Describes how this threat matching this particular asset or dataflow is being handled.
 Can be one of:
-* mitigated - there were changes made in the modeled system to reduce the probability of this threat ocurring or the impact when it does,
+* mitigated - there were changes made in the modeled system to reduce the probability of this threat occurring or the impact when it does,
 * transferred - users of the system are required to mitigate this threat,
 * avoided - this asset or dataflow is removed from the system,
 * accepted - no action is taken as the probability and/or impact is very low
@@ -3157,6 +2183,22 @@ Can be one of:
 </details>
 <h3>Instance variables</h3>
 <dl>
+<dt id="pytm.Finding.assumption"><code class="name">var <span class="ident">assumption</span></code></dt>
+<dd>
+<div class="desc"><p>The assumption, that caused this finding to be excluded</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def __get__(self, instance, owner):
+    # when x.d is called we get here
+    # instance = x
+    # owner = type(x)
+    if instance is None:
+        return self
+    return self.data.get(instance, self.default)</code></pre>
+</details>
+</dd>
 <dt id="pytm.Finding.condition"><code class="name">var <span class="ident">condition</span></code></dt>
 <dd>
 <div class="desc"><p>Threat condition</p></div>
@@ -3305,7 +2347,7 @@ Can be one of:
 <dd>
 <div class="desc"><p>Describes how this threat matching this particular asset or dataflow is being handled.
 Can be one of:
-* mitigated - there were changes made in the modeled system to reduce the probability of this threat ocurring or the impact when it does,
+* mitigated - there were changes made in the modeled system to reduce the probability of this threat occurring or the impact when it does,
 * transferred - users of the system are required to mitigate this threat,
 * avoided - this asset or dataflow is removed from the system,
 * accepted - no action is taken as the probability and/or impact is very low</p></div>
@@ -3397,7 +2439,7 @@ Can be one of:
     shape = {shape};
 
     color = {color};
-    fontcolor = {color};
+    fontcolor = &#34;black&#34;;
     label = &lt;
         &lt;table border=&#34;0&#34; cellborder=&#34;0&#34; cellpadding=&#34;2&#34;&gt;
             &lt;tr&gt;&lt;td&gt;&lt;b&gt;{label}&lt;/b&gt;&lt;/td&gt;&lt;/tr&gt;
@@ -3413,10 +2455,15 @@ Can be one of:
         if levels and not levels &amp; self.levels:
             return &#34;&#34;
 
+        color = self._color()
+
+        if kwargs.get(&#34;colormap&#34;, False):
+            color = sev_to_color(self.severity)
+
         return self._dfd_template().format(
             uniq_name=self._uniq_name(),
             label=self._label(),
-            color=self._color(),
+            color=color,
             shape=self._shape(),
         )
 
@@ -3576,41 +2623,10 @@ Can be one of:
 
     codeType = varString(&#34;Unmanaged&#34;)
     implementsCommunicationProtocol = varBool(False)
-    providesConfidentiality = varBool(False)
-    providesIntegrity = varBool(False)
-    isResilient = varBool(False)
     tracksExecutionFlow = varBool(False)
-    implementsCSRFToken = varBool(False)
-    handlesResourceConsumption = varBool(False)
-    handlesCrashes = varBool(False)
-    handlesInterruptions = varBool(False)
     implementsAPI = varBool(False)
-    usesSecureFunctions = varBool(False)
     environment = varString(&#34;&#34;)
-    disablesiFrames = varBool(False)
-    implementsPOLP = varBool(
-        False,
-        doc=&#34;&#34;&#34;The principle of least privilege (PoLP),
-also known as the principle of minimal privilege or the principle of least authority,
-requires that in a particular abstraction layer of a computing environment,
-every module (such as a process, a user, or a program, depending on the subject)
-must be able to access only the information and resources
-that are necessary for its legitimate purpose.&#34;&#34;&#34;,
-    )
-    usesParameterizedInput = varBool(False)
     allowsClientSideScripting = varBool(False)
-    usesStrongSessionIdentifiers = varBool(False)
-    encryptsCookies = varBool(False)
-    usesMFA = varBool(
-        False,
-        doc=&#34;&#34;&#34;Multi-factor authentication is an authentication method
-in which a computer user is granted access only after successfully presenting two
-or more pieces of evidence (or factors) to an authentication mechanism: knowledge
-(something the user and only the user knows), possession (something the user
-and only the user has), and inherence (something the user and only the user is).&#34;&#34;&#34;,
-    )
-    encryptsSessionData = varBool(False)
-    verifySessionIdentifiers = varBool(False)
 
     def __init__(self, name, **kwargs):
         super().__init__(name, **kwargs)
@@ -3661,103 +2677,7 @@ and only the user has), and inherence (something the user and only the user is).
     return self.data.get(instance, self.default)</code></pre>
 </details>
 </dd>
-<dt id="pytm.Process.disablesiFrames"><code class="name">var <span class="ident">disablesiFrames</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Process.encryptsCookies"><code class="name">var <span class="ident">encryptsCookies</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Process.encryptsSessionData"><code class="name">var <span class="ident">encryptsSessionData</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
 <dt id="pytm.Process.environment"><code class="name">var <span class="ident">environment</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Process.handlesCrashes"><code class="name">var <span class="ident">handlesCrashes</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Process.handlesInterruptions"><code class="name">var <span class="ident">handlesInterruptions</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Process.handlesResourceConsumption"><code class="name">var <span class="ident">handlesResourceConsumption</span></code></dt>
 <dd>
 <div class="desc"></div>
 <details class="source">
@@ -3789,92 +2709,7 @@ and only the user has), and inherence (something the user and only the user is).
     return self.data.get(instance, self.default)</code></pre>
 </details>
 </dd>
-<dt id="pytm.Process.implementsCSRFToken"><code class="name">var <span class="ident">implementsCSRFToken</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
 <dt id="pytm.Process.implementsCommunicationProtocol"><code class="name">var <span class="ident">implementsCommunicationProtocol</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Process.implementsPOLP"><code class="name">var <span class="ident">implementsPOLP</span></code></dt>
-<dd>
-<div class="desc"><p>The principle of least privilege (PoLP),
-also known as the principle of minimal privilege or the principle of least authority,
-requires that in a particular abstraction layer of a computing environment,
-every module (such as a process, a user, or a program, depending on the subject)
-must be able to access only the information and resources
-that are necessary for its legitimate purpose.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Process.isResilient"><code class="name">var <span class="ident">isResilient</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Process.providesConfidentiality"><code class="name">var <span class="ident">providesConfidentiality</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Process.providesIntegrity"><code class="name">var <span class="ident">providesIntegrity</span></code></dt>
 <dd>
 <div class="desc"></div>
 <details class="source">
@@ -3906,90 +2741,6 @@ that are necessary for its legitimate purpose.</p></div>
     return self.data.get(instance, self.default)</code></pre>
 </details>
 </dd>
-<dt id="pytm.Process.usesMFA"><code class="name">var <span class="ident">usesMFA</span></code></dt>
-<dd>
-<div class="desc"><p>Multi-factor authentication is an authentication method
-in which a computer user is granted access only after successfully presenting two
-or more pieces of evidence (or factors) to an authentication mechanism: knowledge
-(something the user and only the user knows), possession (something the user
-and only the user has), and inherence (something the user and only the user is).</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Process.usesParameterizedInput"><code class="name">var <span class="ident">usesParameterizedInput</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Process.usesSecureFunctions"><code class="name">var <span class="ident">usesSecureFunctions</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Process.usesStrongSessionIdentifiers"><code class="name">var <span class="ident">usesStrongSessionIdentifiers</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Process.verifySessionIdentifiers"><code class="name">var <span class="ident">verifySessionIdentifiers</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
 </dl>
 </dd>
 <dt id="pytm.Server"><code class="flex name class">
@@ -4005,33 +2756,10 @@ and only the user has), and inherence (something the user and only the user is).
 <pre><code class="python">class Server(Asset):
     &#34;&#34;&#34;An entity processing data&#34;&#34;&#34;
 
-    providesConfidentiality = varBool(False)
-    providesIntegrity = varBool(False)
-    validatesHeaders = varBool(False)
-    encodesHeaders = varBool(False)
-    implementsCSRFToken = varBool(False)
-    isResilient = varBool(False)
     usesSessionTokens = varBool(False)
-    usesEncryptionAlgorithm = varString(&#34;&#34;)
     usesCache = varBool(False)
     usesVPN = varBool(False)
-    usesCodeSigning = varBool(False)
-    validatesContentType = varBool(False)
-    invokesScriptFilters = varBool(False)
-    usesStrongSessionIdentifiers = varBool(False)
-    implementsServerSideValidation = varBool(False)
     usesXMLParser = varBool(False)
-    disablesDTD = varBool(False)
-    implementsStrictHTTPValidation = varBool(False)
-    implementsPOLP = varBool(
-        False,
-        doc=&#34;&#34;&#34;The principle of least privilege (PoLP),
-also known as the principle of minimal privilege or the principle of least authority,
-requires that in a particular abstraction layer of a computing environment,
-every module (such as a process, a user, or a program, depending on the subject)
-must be able to access only the information and resources
-that are necessary for its legitimate purpose.&#34;&#34;&#34;,
-    )
 
     def __init__(self, name, **kwargs):
         super().__init__(name, **kwargs)
@@ -4046,171 +2774,6 @@ that are necessary for its legitimate purpose.&#34;&#34;&#34;,
 </ul>
 <h3>Instance variables</h3>
 <dl>
-<dt id="pytm.Server.disablesDTD"><code class="name">var <span class="ident">disablesDTD</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Server.encodesHeaders"><code class="name">var <span class="ident">encodesHeaders</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Server.implementsCSRFToken"><code class="name">var <span class="ident">implementsCSRFToken</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Server.implementsPOLP"><code class="name">var <span class="ident">implementsPOLP</span></code></dt>
-<dd>
-<div class="desc"><p>The principle of least privilege (PoLP),
-also known as the principle of minimal privilege or the principle of least authority,
-requires that in a particular abstraction layer of a computing environment,
-every module (such as a process, a user, or a program, depending on the subject)
-must be able to access only the information and resources
-that are necessary for its legitimate purpose.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Server.implementsServerSideValidation"><code class="name">var <span class="ident">implementsServerSideValidation</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Server.implementsStrictHTTPValidation"><code class="name">var <span class="ident">implementsStrictHTTPValidation</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Server.invokesScriptFilters"><code class="name">var <span class="ident">invokesScriptFilters</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Server.isResilient"><code class="name">var <span class="ident">isResilient</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Server.providesConfidentiality"><code class="name">var <span class="ident">providesConfidentiality</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Server.providesIntegrity"><code class="name">var <span class="ident">providesIntegrity</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
 <dt id="pytm.Server.usesCache"><code class="name">var <span class="ident">usesCache</span></code></dt>
 <dd>
 <div class="desc"></div>
@@ -4227,55 +2790,7 @@ that are necessary for its legitimate purpose.</p></div>
     return self.data.get(instance, self.default)</code></pre>
 </details>
 </dd>
-<dt id="pytm.Server.usesCodeSigning"><code class="name">var <span class="ident">usesCodeSigning</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Server.usesEncryptionAlgorithm"><code class="name">var <span class="ident">usesEncryptionAlgorithm</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
 <dt id="pytm.Server.usesSessionTokens"><code class="name">var <span class="ident">usesSessionTokens</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Server.usesStrongSessionIdentifiers"><code class="name">var <span class="ident">usesStrongSessionIdentifiers</span></code></dt>
 <dd>
 <div class="desc"></div>
 <details class="source">
@@ -4308,38 +2823,6 @@ that are necessary for its legitimate purpose.</p></div>
 </details>
 </dd>
 <dt id="pytm.Server.usesXMLParser"><code class="name">var <span class="ident">usesXMLParser</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Server.validatesContentType"><code class="name">var <span class="ident">validatesContentType</span></code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def __get__(self, instance, owner):
-    # when x.d is called we get here
-    # instance = x
-    # owner = type(x)
-    if instance is None:
-        return self
-    return self.data.get(instance, self.default)</code></pre>
-</details>
-</dd>
-<dt id="pytm.Server.validatesHeaders"><code class="name">var <span class="ident">validatesHeaders</span></code></dt>
 <dd>
 <div class="desc"></div>
 <details class="source">
@@ -4466,7 +2949,14 @@ and holds all details during a run</p></div>
     _data = []
     _threatsExcluded = []
     _sf = None
-    _duplicate_ignored_attrs = &#34;name&#34;, &#34;note&#34;, &#34;order&#34;, &#34;response&#34;, &#34;responseTo&#34; &#34;controls&#34;
+    _duplicate_ignored_attrs = (
+        &#34;name&#34;,
+        &#34;note&#34;,
+        &#34;order&#34;,
+        &#34;response&#34;,
+        &#34;responseTo&#34;,
+        &#34;controls&#34;,
+    )
     name = varString(&#34;&#34;, required=True, doc=&#34;Model name&#34;)
     description = varString(&#34;&#34;, required=True, doc=&#34;Model description&#34;)
     threatsFile = varString(
@@ -4477,7 +2967,12 @@ and holds all details during a run</p></div>
     isOrdered = varBool(False, doc=&#34;Automatically order all Dataflows&#34;)
     mergeResponses = varBool(False, doc=&#34;Merge response edges in DFDs&#34;)
     ignoreUnused = varBool(False, doc=&#34;Ignore elements not used in any Dataflow&#34;)
-    findings = varFindings([], doc=&#34;threats found for elements of this model&#34;)
+    findings = varFindings([], doc=&#34;Threats found for elements of this model&#34;)
+    excluded_findings = varFindings(
+        [],
+        doc=&#34;Threats found for elements of this model, &#34;
+        &#34;that were excluded on a per-element basis, using the Assumptions class&#34;
+    )
     onDuplicates = varAction(
         Action.NO_ACTION,
         doc=&#34;&#34;&#34;How to handle duplicate Dataflow
@@ -4488,6 +2983,7 @@ with same properties, except name and notes&#34;&#34;&#34;,
         required=False,
         doc=&#34;A list of assumptions about the design/model.&#34;,
     )
+    _colormap = False
 
     def __init__(self, name, **kwargs):
         for key, value in kwargs.items():
@@ -4507,23 +3003,31 @@ with same properties, except name and notes&#34;&#34;&#34;,
         cls._threats = []
         cls._boundaries = []
         cls._data = []
+        cls._threatsExcluded = []
 
     def _init_threats(self):
         TM._threats = []
         self._add_threats()
 
     def _add_threats(self):
-        with open(self.threatsFile, &#34;r&#34;, encoding=&#34;utf8&#34;) as threat_file:
-            threats_json = json.load(threat_file)
+        try:
+            with open(self.threatsFile, &#34;r&#34;, encoding=&#34;utf8&#34;) as threat_file:
+                threats_json = json.load(threat_file)
+        except (FileNotFoundError, PermissionError, IsADirectoryError) as e:
+            raise UIError(
+                e, f&#34;while trying to open the the threat file ({self.threatsFile}).&#34;
+            )
 
         for i in threats_json:
             TM._threats.append(Threat(**i))
 
     def resolve(self):
         finding_count = 0
+        excluded_finding_count = 0
         findings = []
+        excluded_findings = []
         elements = defaultdict(list)
-        for e in TM._elements:
+        for e in TM._elements:  # type: Element
             if not e.inScope:
                 continue
 
@@ -4537,16 +3041,31 @@ with same properties, except name and notes&#34;&#34;&#34;,
             except AttributeError:
                 pass
 
-            for t in TM._threats:
+            for t in TM._threats:  # type: Threat
                 if not t.apply(e) and t.id not in override_ids:
+                    continue
+
+                if t.id in TM._threatsExcluded:
+                    continue
+
+                _continue = False
+                for assumption in e.assumptions:  # type: Assumption
+                    if t.id in assumption.exclude:
+                        excluded_finding_count += 1
+                        f = Finding(e, id=str(excluded_finding_count), threat=t, assumption=assumption)
+                        excluded_findings.append(f)
+                        _continue = True
+                        break
+                if _continue:
                     continue
 
                 finding_count += 1
                 f = Finding(e, id=str(finding_count), threat=t)
-                logger.debug(f&#34;new finding: {f}&#34;)
                 findings.append(f)
                 elements[e].append(f)
+                e._set_severity(f.severity)
         self.findings = findings
+        self.excluded_findings = excluded_findings
         for e, findings in elements.items():
             e.findings = findings
 
@@ -4608,9 +3127,9 @@ a brief description of the system being modeled.&#34;&#34;&#34;
                     right._is_drawn = True
                     continue
 
-                    left_controls_attrs = left.controls._attr_values()
+                left_controls_attrs = left.controls._attr_values()
                 right_controls_attrs = right.controls._attr_values()
-                #for a in self._duplicate_ignored_attrs:
+                # for a in self._duplicate_ignored_attrs:
                 #    del left_controls_attrs[a], right_controls_attrs[a]
                 if left_controls_attrs != right_controls_attrs:
                     continue
@@ -4732,27 +3251,49 @@ a brief description of the system being modeled.&#34;&#34;&#34;
         )
 
     def report(self, template_path):
-        with open(template_path) as file:
-            template = file.read()
+        try:
+            with open(template_path) as file:
+                template = file.read()
+        except (FileNotFoundError, PermissionError, IsADirectoryError) as e:
+            raise UIError(
+                e, f&#34;while trying to open the report template file ({template_path}).&#34;
+            )
 
         threats = encode_threat_data(TM._threats)
         findings = encode_threat_data(self.findings)
 
+        elements = encode_element_threat_data(TM._elements)
+        assets = encode_element_threat_data(TM._assets)
+        actors = encode_element_threat_data(TM._actors)
+        boundaries = encode_element_threat_data(TM._boundaries)
+        flows = encode_element_threat_data(TM._flows)
+
         data = {
             &#34;tm&#34;: self,
-            &#34;dataflows&#34;: TM._flows,
+            &#34;dataflows&#34;: flows,
             &#34;threats&#34;: threats,
             &#34;findings&#34;: findings,
-            &#34;elements&#34;: TM._elements,
-            &#34;assets&#34;: TM._assets,
-            &#34;actors&#34;: TM._actors,
-            &#34;boundaries&#34;: TM._boundaries,
+            &#34;elements&#34;: elements,
+            &#34;assets&#34;: assets,
+            &#34;actors&#34;: actors,
+            &#34;boundaries&#34;: boundaries,
             &#34;data&#34;: TM._data,
         }
 
         return self._sf.format(template, **data)
 
     def process(self):
+        try:
+            self._process()
+        except UIError as e:
+            erromsg = f&#34;&#34;&#34;Failed to excecute
+    {e.context}
+    {e.error}
+&#34;&#34;&#34;
+            sys.stderr.write(erromsg)
+            sys.exit(127)
+
+    def _process(self):
         self.check()
         result = get_args()
         logging.basicConfig(level=logging.INFO, format=&#34;%(levelname)s: %(message)s&#34;)
@@ -4760,11 +3301,16 @@ a brief description of the system being modeled.&#34;&#34;&#34;
         if result.debug:
             logger.setLevel(logging.DEBUG)
 
+        if result.exclude is not None:
+            TM._threatsExcluded = result.exclude.split(&#34;,&#34;)
+
         if result.seq is True:
             print(self.seq())
 
         if result.dfd is True:
-            print(self.dfd(levels=(result.levels or set())))
+            if result.colormap is True:
+                self.resolve()
+            print(self.dfd(colormap=result.colormap, levels=(result.levels or set())))
 
         if (
             result.report is not None
@@ -4778,14 +3324,16 @@ a brief description of the system being modeled.&#34;&#34;&#34;
             self.sqlDump(result.sqldump)
 
         if result.json:
-            with open(result.json, &#34;w&#34;, encoding=&#34;utf8&#34;) as f:
-                json.dump(self, f, default=to_serializable)
+            try:
+                with open(result.json, &#34;w&#34;, encoding=&#34;utf8&#34;) as f:
+                    json.dump(self, f, default=to_serializable)
+            except (FileExistsError, PermissionError, IsADirectoryError) as e:
+                raise UIError(
+                    e, f&#34;while trying to write to the result file ({result.json})&#34;
+                )
 
         if result.report is not None:
             print(self.report(result.report))
-
-        if result.exclude is not None:
-            TM._threatsExcluded = result.exclude.split(&#34;,&#34;)
 
         if result.describe is not None:
             _describe_classes(result.describe.split())
@@ -4813,7 +3361,6 @@ a brief description of the system being modeled.&#34;&#34;&#34;
         print(f&#34;Checking for code {days} days older than this model.&#34;)
 
         for e in TM._elements:
-
             for src in e.sourceFiles:
                 try:
                     src_mtime = datetime.fromtimestamp(
@@ -4842,6 +3389,25 @@ a brief description of the system being modeled.&#34;&#34;&#34;
 
     def sqlDump(self, filename):
         try:
+            from pydal import DAL, Field
+        except ImportError as e:
+            raise UIError(
+                e, &#34;&#34;&#34;This feature requires the pyDAL package,
+    Please install the package via pip or your packagemanger of choice.
+                &#34;&#34;&#34;
+            )
+
+        @lru_cache(maxsize=None)
+        def get_table(db, klass):
+            name = klass.__name__
+            fields = [
+                Field(&#34;SID&#34; if i == &#34;id&#34; else i)
+                for i in dir(klass)
+                if not i.startswith(&#34;_&#34;) and not callable(getattr(klass, i))
+            ]
+            return db.define_table(name, fields)
+
+        try:
             rmtree(&#34;./sqldump&#34;)
             os.mkdir(&#34;./sqldump&#34;)
         except OSError as e:
@@ -4867,10 +3433,10 @@ a brief description of the system being modeled.&#34;&#34;&#34;
             Data,
             Finding,
         ):
-            self.get_table(db, klass)
+            get_table(db, klass)
 
         for e in TM._threats + TM._data + TM._elements + self.findings + [self]:
-            table = self.get_table(db, e.__class__)
+            table = get_table(db, e.__class__)
             row = {}
             for k, v in serialize(e).items():
                 if k == &#34;id&#34;:
@@ -4878,17 +3444,7 @@ a brief description of the system being modeled.&#34;&#34;&#34;
                 row[k] = &#34;, &#34;.join(str(i) for i in v) if isinstance(v, list) else v
             db[table].bulk_insert([row])
 
-        db.close()
-
-    @lru_cache(maxsize=None)
-    def get_table(self, db, klass):
-        name = klass.__name__
-        fields = [
-            Field(&#34;SID&#34; if i == &#34;id&#34; else i)
-            for i in dir(klass)
-            if not i.startswith(&#34;_&#34;) and not callable(getattr(klass, i))
-        ]
-        return db.define_table(name, fields)</code></pre>
+        db.close()</code></pre>
 </details>
 <h3>Static methods</h3>
 <dl>
@@ -4909,7 +3465,8 @@ def reset(cls):
     cls._assets = []
     cls._threats = []
     cls._boundaries = []
-    cls._data = []</code></pre>
+    cls._data = []
+    cls._threatsExcluded = []</code></pre>
 </details>
 </dd>
 </dl>
@@ -4947,9 +3504,25 @@ def reset(cls):
     return self.data.get(instance, self.default)</code></pre>
 </details>
 </dd>
+<dt id="pytm.TM.excluded_findings"><code class="name">var <span class="ident">excluded_findings</span></code></dt>
+<dd>
+<div class="desc"><p>Threats found for elements of this model, that were excluded on a per-element basis, using the Assumptions class</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def __get__(self, instance, owner):
+    # when x.d is called we get here
+    # instance = x
+    # owner = type(x)
+    if instance is None:
+        return self
+    return self.data.get(instance, self.default)</code></pre>
+</details>
+</dd>
 <dt id="pytm.TM.findings"><code class="name">var <span class="ident">findings</span></code></dt>
 <dd>
-<div class="desc"><p>threats found for elements of this model</p></div>
+<div class="desc"><p>Threats found for elements of this model</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -5063,26 +3636,6 @@ with same properties, except name and notes</p></div>
 </dl>
 <h3>Methods</h3>
 <dl>
-<dt id="pytm.TM.get_table"><code class="name flex">
-<span>def <span class="ident">get_table</span></span>(<span>self, db, klass)</span>
-</code></dt>
-<dd>
-<div class="desc"></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">@lru_cache(maxsize=None)
-def get_table(self, db, klass):
-    name = klass.__name__
-    fields = [
-        Field(&#34;SID&#34; if i == &#34;id&#34; else i)
-        for i in dir(klass)
-        if not i.startswith(&#34;_&#34;) and not callable(getattr(klass, i))
-    ]
-    return db.define_table(name, fields)</code></pre>
-</details>
-</dd>
 <dt id="pytm.TM.process"><code class="name flex">
 <span>def <span class="ident">process</span></span>(<span>self)</span>
 </code></dt>
@@ -5092,52 +3645,16 @@ def get_table(self, db, klass):
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def process(self):
-    self.check()
-    result = get_args()
-    logging.basicConfig(level=logging.INFO, format=&#34;%(levelname)s: %(message)s&#34;)
-
-    if result.debug:
-        logger.setLevel(logging.DEBUG)
-
-    if result.seq is True:
-        print(self.seq())
-
-    if result.dfd is True:
-        print(self.dfd(levels=(result.levels or set())))
-
-    if (
-        result.report is not None
-        or result.json is not None
-        or result.sqldump is not None
-        or result.stale_days is not None
-    ):
-        self.resolve()
-
-    if result.sqldump is not None:
-        self.sqlDump(result.sqldump)
-
-    if result.json:
-        with open(result.json, &#34;w&#34;, encoding=&#34;utf8&#34;) as f:
-            json.dump(self, f, default=to_serializable)
-
-    if result.report is not None:
-        print(self.report(result.report))
-
-    if result.exclude is not None:
-        TM._threatsExcluded = result.exclude.split(&#34;,&#34;)
-
-    if result.describe is not None:
-        _describe_classes(result.describe.split())
-
-    if result.list_elements:
-        _list_elements()
-
-    if result.list is True:
-        [print(&#34;{} - {}&#34;.format(t.id, t.description)) for t in TM._threats]
-
-    if result.stale_days is not None:
-        print(self._stale(result.stale_days))</code></pre>
+<pre><code class="python">    def process(self):
+        try:
+            self._process()
+        except UIError as e:
+            erromsg = f&#34;&#34;&#34;Failed to excecute
+    {e.context}
+    {e.error}
+&#34;&#34;&#34;
+            sys.stderr.write(erromsg)
+            sys.exit(127)</code></pre>
 </details>
 </dd>
 <dt id="pytm.TM.report"><code class="name flex">
@@ -5150,21 +3667,32 @@ def get_table(self, db, klass):
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def report(self, template_path):
-    with open(template_path) as file:
-        template = file.read()
+    try:
+        with open(template_path) as file:
+            template = file.read()
+    except (FileNotFoundError, PermissionError, IsADirectoryError) as e:
+        raise UIError(
+            e, f&#34;while trying to open the report template file ({template_path}).&#34;
+        )
 
     threats = encode_threat_data(TM._threats)
     findings = encode_threat_data(self.findings)
 
+    elements = encode_element_threat_data(TM._elements)
+    assets = encode_element_threat_data(TM._assets)
+    actors = encode_element_threat_data(TM._actors)
+    boundaries = encode_element_threat_data(TM._boundaries)
+    flows = encode_element_threat_data(TM._flows)
+
     data = {
         &#34;tm&#34;: self,
-        &#34;dataflows&#34;: TM._flows,
+        &#34;dataflows&#34;: flows,
         &#34;threats&#34;: threats,
         &#34;findings&#34;: findings,
-        &#34;elements&#34;: TM._elements,
-        &#34;assets&#34;: TM._assets,
-        &#34;actors&#34;: TM._actors,
-        &#34;boundaries&#34;: TM._boundaries,
+        &#34;elements&#34;: elements,
+        &#34;assets&#34;: assets,
+        &#34;actors&#34;: actors,
+        &#34;boundaries&#34;: boundaries,
         &#34;data&#34;: TM._data,
     }
 
@@ -5182,9 +3710,11 @@ def get_table(self, db, klass):
 </summary>
 <pre><code class="python">def resolve(self):
     finding_count = 0
+    excluded_finding_count = 0
     findings = []
+    excluded_findings = []
     elements = defaultdict(list)
-    for e in TM._elements:
+    for e in TM._elements:  # type: Element
         if not e.inScope:
             continue
 
@@ -5198,16 +3728,31 @@ def get_table(self, db, klass):
         except AttributeError:
             pass
 
-        for t in TM._threats:
+        for t in TM._threats:  # type: Threat
             if not t.apply(e) and t.id not in override_ids:
+                continue
+
+            if t.id in TM._threatsExcluded:
+                continue
+
+            _continue = False
+            for assumption in e.assumptions:  # type: Assumption
+                if t.id in assumption.exclude:
+                    excluded_finding_count += 1
+                    f = Finding(e, id=str(excluded_finding_count), threat=t, assumption=assumption)
+                    excluded_findings.append(f)
+                    _continue = True
+                    break
+            if _continue:
                 continue
 
             finding_count += 1
             f = Finding(e, id=str(finding_count), threat=t)
-            logger.debug(f&#34;new finding: {f}&#34;)
             findings.append(f)
             elements[e].append(f)
+            e._set_severity(f.severity)
     self.findings = findings
+    self.excluded_findings = excluded_findings
     for e, findings in elements.items():
         e.findings = findings</code></pre>
 </details>
@@ -5222,6 +3767,25 @@ def get_table(self, db, klass):
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">def sqlDump(self, filename):
+    try:
+        from pydal import DAL, Field
+    except ImportError as e:
+        raise UIError(
+            e, &#34;&#34;&#34;This feature requires the pyDAL package,
+Please install the package via pip or your packagemanger of choice.
+            &#34;&#34;&#34;
+        )
+
+    @lru_cache(maxsize=None)
+    def get_table(db, klass):
+        name = klass.__name__
+        fields = [
+            Field(&#34;SID&#34; if i == &#34;id&#34; else i)
+            for i in dir(klass)
+            if not i.startswith(&#34;_&#34;) and not callable(getattr(klass, i))
+        ]
+        return db.define_table(name, fields)
+
     try:
         rmtree(&#34;./sqldump&#34;)
         os.mkdir(&#34;./sqldump&#34;)
@@ -5248,10 +3812,10 @@ def get_table(self, db, klass):
         Data,
         Finding,
     ):
-        self.get_table(db, klass)
+        get_table(db, klass)
 
     for e in TM._threats + TM._data + TM._elements + self.findings + [self]:
-        table = self.get_table(db, e.__class__)
+        table = get_table(db, e.__class__)
         row = {}
         for k, v in serialize(e).items():
             if k == &#34;id&#34;:
@@ -5285,8 +3849,10 @@ def get_table(self, db, klass):
 to a boolean True or False&#34;&#34;&#34;,
     )
     details = varString(&#34;&#34;)
+    likelihood = varString(&#34;&#34;)
     severity = varString(&#34;&#34;)
     mitigations = varString(&#34;&#34;)
+    prerequisites = varString(&#34;&#34;)
     example = varString(&#34;&#34;)
     references = varString(&#34;&#34;)
     target = ()
@@ -5294,6 +3860,7 @@ to a boolean True or False&#34;&#34;&#34;,
     def __init__(self, **kwargs):
         self.id = kwargs[&#34;SID&#34;]
         self.description = kwargs.get(&#34;description&#34;, &#34;&#34;)
+        self.likelihood = kwargs.get(&#34;Likelihood Of Attack&#34;, &#34;&#34;)
         self.condition = kwargs.get(&#34;condition&#34;, &#34;True&#34;)
         target = kwargs.get(&#34;target&#34;, &#34;Element&#34;)
         if not isinstance(target, str) and isinstance(target, Iterable):
@@ -5304,6 +3871,7 @@ to a boolean True or False&#34;&#34;&#34;,
         self.details = kwargs.get(&#34;details&#34;, &#34;&#34;)
         self.severity = kwargs.get(&#34;severity&#34;, &#34;&#34;)
         self.mitigations = kwargs.get(&#34;mitigations&#34;, &#34;&#34;)
+        self.prerequisites = kwargs.get(&#34;prerequisites&#34;, &#34;&#34;)
         self.example = kwargs.get(&#34;example&#34;, &#34;&#34;)
         self.references = kwargs.get(&#34;references&#34;, &#34;&#34;)
 
@@ -5416,7 +3984,39 @@ to a boolean True or False</p></div>
     return self.data.get(instance, self.default)</code></pre>
 </details>
 </dd>
+<dt id="pytm.Threat.likelihood"><code class="name">var <span class="ident">likelihood</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def __get__(self, instance, owner):
+    # when x.d is called we get here
+    # instance = x
+    # owner = type(x)
+    if instance is None:
+        return self
+    return self.data.get(instance, self.default)</code></pre>
+</details>
+</dd>
 <dt id="pytm.Threat.mitigations"><code class="name">var <span class="ident">mitigations</span></code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def __get__(self, instance, owner):
+    # when x.d is called we get here
+    # instance = x
+    # owner = type(x)
+    if instance is None:
+        return self
+    return self.data.get(instance, self.default)</code></pre>
+</details>
+</dd>
+<dt id="pytm.Threat.prerequisites"><code class="name">var <span class="ident">prerequisites</span></code></dt>
 <dd>
 <div class="desc"></div>
 <details class="source">
@@ -5493,6 +4093,11 @@ to a boolean True or False</p></div>
 <ul></ul>
 </div>
 <ul id="index">
+<li><h3><a href="#header-submodules">Sub-modules</a></h3>
+<ul>
+<li><code><a title="pytm.report_util" href="report_util.html">pytm.report_util</a></code></li>
+</ul>
+</li>
 <li><h3><a href="#header-functions">Functions</a></h3>
 <ul class="">
 <li><code><a title="pytm.load" href="#pytm.load">load</a></code></li>
@@ -5511,16 +4116,21 @@ to a boolean True or False</p></div>
 </li>
 <li>
 <h4><code><a title="pytm.Actor" href="#pytm.Actor">Actor</a></code></h4>
-<ul class="">
-<li><code><a title="pytm.Actor.authenticatesDestination" href="#pytm.Actor.authenticatesDestination">authenticatesDestination</a></code></li>
-<li><code><a title="pytm.Actor.checksDestinationRevocation" href="#pytm.Actor.checksDestinationRevocation">checksDestinationRevocation</a></code></li>
+<ul class="two-column">
 <li><code><a title="pytm.Actor.data" href="#pytm.Actor.data">data</a></code></li>
 <li><code><a title="pytm.Actor.inputs" href="#pytm.Actor.inputs">inputs</a></code></li>
 <li><code><a title="pytm.Actor.isAdmin" href="#pytm.Actor.isAdmin">isAdmin</a></code></li>
 <li><code><a title="pytm.Actor.outputs" href="#pytm.Actor.outputs">outputs</a></code></li>
 <li><code><a title="pytm.Actor.port" href="#pytm.Actor.port">port</a></code></li>
 <li><code><a title="pytm.Actor.protocol" href="#pytm.Actor.protocol">protocol</a></code></li>
-<li><code><a title="pytm.Actor.providesIntegrity" href="#pytm.Actor.providesIntegrity">providesIntegrity</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="pytm.Assumption" href="#pytm.Assumption">Assumption</a></code></h4>
+<ul class="">
+<li><code><a title="pytm.Assumption.description" href="#pytm.Assumption.description">description</a></code></li>
+<li><code><a title="pytm.Assumption.exclude" href="#pytm.Assumption.exclude">exclude</a></code></li>
+<li><code><a title="pytm.Assumption.name" href="#pytm.Assumption.name">name</a></code></li>
 </ul>
 </li>
 <li>
@@ -5538,54 +4148,6 @@ to a boolean True or False</p></div>
 <li><code><a title="pytm.Classification.SENSITIVE" href="#pytm.Classification.SENSITIVE">SENSITIVE</a></code></li>
 <li><code><a title="pytm.Classification.TOP_SECRET" href="#pytm.Classification.TOP_SECRET">TOP_SECRET</a></code></li>
 <li><code><a title="pytm.Classification.UNKNOWN" href="#pytm.Classification.UNKNOWN">UNKNOWN</a></code></li>
-</ul>
-</li>
-<li>
-<h4><code><a title="pytm.Controls" href="#pytm.Controls">Controls</a></code></h4>
-<ul class="">
-<li><code><a title="pytm.Controls.authenticatesDestination" href="#pytm.Controls.authenticatesDestination">authenticatesDestination</a></code></li>
-<li><code><a title="pytm.Controls.authenticatesSource" href="#pytm.Controls.authenticatesSource">authenticatesSource</a></code></li>
-<li><code><a title="pytm.Controls.authenticationScheme" href="#pytm.Controls.authenticationScheme">authenticationScheme</a></code></li>
-<li><code><a title="pytm.Controls.authorizesSource" href="#pytm.Controls.authorizesSource">authorizesSource</a></code></li>
-<li><code><a title="pytm.Controls.checksDestinationRevocation" href="#pytm.Controls.checksDestinationRevocation">checksDestinationRevocation</a></code></li>
-<li><code><a title="pytm.Controls.checksInputBounds" href="#pytm.Controls.checksInputBounds">checksInputBounds</a></code></li>
-<li><code><a title="pytm.Controls.definesConnectionTimeout" href="#pytm.Controls.definesConnectionTimeout">definesConnectionTimeout</a></code></li>
-<li><code><a title="pytm.Controls.disablesDTD" href="#pytm.Controls.disablesDTD">disablesDTD</a></code></li>
-<li><code><a title="pytm.Controls.disablesiFrames" href="#pytm.Controls.disablesiFrames">disablesiFrames</a></code></li>
-<li><code><a title="pytm.Controls.encodesHeaders" href="#pytm.Controls.encodesHeaders">encodesHeaders</a></code></li>
-<li><code><a title="pytm.Controls.encodesOutput" href="#pytm.Controls.encodesOutput">encodesOutput</a></code></li>
-<li><code><a title="pytm.Controls.encryptsCookies" href="#pytm.Controls.encryptsCookies">encryptsCookies</a></code></li>
-<li><code><a title="pytm.Controls.encryptsSessionData" href="#pytm.Controls.encryptsSessionData">encryptsSessionData</a></code></li>
-<li><code><a title="pytm.Controls.handlesCrashes" href="#pytm.Controls.handlesCrashes">handlesCrashes</a></code></li>
-<li><code><a title="pytm.Controls.handlesInterruptions" href="#pytm.Controls.handlesInterruptions">handlesInterruptions</a></code></li>
-<li><code><a title="pytm.Controls.handlesResourceConsumption" href="#pytm.Controls.handlesResourceConsumption">handlesResourceConsumption</a></code></li>
-<li><code><a title="pytm.Controls.hasAccessControl" href="#pytm.Controls.hasAccessControl">hasAccessControl</a></code></li>
-<li><code><a title="pytm.Controls.implementsAuthenticationScheme" href="#pytm.Controls.implementsAuthenticationScheme">implementsAuthenticationScheme</a></code></li>
-<li><code><a title="pytm.Controls.implementsCSRFToken" href="#pytm.Controls.implementsCSRFToken">implementsCSRFToken</a></code></li>
-<li><code><a title="pytm.Controls.implementsNonce" href="#pytm.Controls.implementsNonce">implementsNonce</a></code></li>
-<li><code><a title="pytm.Controls.implementsPOLP" href="#pytm.Controls.implementsPOLP">implementsPOLP</a></code></li>
-<li><code><a title="pytm.Controls.implementsServerSideValidation" href="#pytm.Controls.implementsServerSideValidation">implementsServerSideValidation</a></code></li>
-<li><code><a title="pytm.Controls.implementsStrictHTTPValidation" href="#pytm.Controls.implementsStrictHTTPValidation">implementsStrictHTTPValidation</a></code></li>
-<li><code><a title="pytm.Controls.invokesScriptFilters" href="#pytm.Controls.invokesScriptFilters">invokesScriptFilters</a></code></li>
-<li><code><a title="pytm.Controls.isEncrypted" href="#pytm.Controls.isEncrypted">isEncrypted</a></code></li>
-<li><code><a title="pytm.Controls.isEncryptedAtRest" href="#pytm.Controls.isEncryptedAtRest">isEncryptedAtRest</a></code></li>
-<li><code><a title="pytm.Controls.isHardened" href="#pytm.Controls.isHardened">isHardened</a></code></li>
-<li><code><a title="pytm.Controls.isResilient" href="#pytm.Controls.isResilient">isResilient</a></code></li>
-<li><code><a title="pytm.Controls.providesConfidentiality" href="#pytm.Controls.providesConfidentiality">providesConfidentiality</a></code></li>
-<li><code><a title="pytm.Controls.providesIntegrity" href="#pytm.Controls.providesIntegrity">providesIntegrity</a></code></li>
-<li><code><a title="pytm.Controls.sanitizesInput" href="#pytm.Controls.sanitizesInput">sanitizesInput</a></code></li>
-<li><code><a title="pytm.Controls.tracksExecutionFlow" href="#pytm.Controls.tracksExecutionFlow">tracksExecutionFlow</a></code></li>
-<li><code><a title="pytm.Controls.usesCodeSigning" href="#pytm.Controls.usesCodeSigning">usesCodeSigning</a></code></li>
-<li><code><a title="pytm.Controls.usesEncryptionAlgorithm" href="#pytm.Controls.usesEncryptionAlgorithm">usesEncryptionAlgorithm</a></code></li>
-<li><code><a title="pytm.Controls.usesMFA" href="#pytm.Controls.usesMFA">usesMFA</a></code></li>
-<li><code><a title="pytm.Controls.usesParameterizedInput" href="#pytm.Controls.usesParameterizedInput">usesParameterizedInput</a></code></li>
-<li><code><a title="pytm.Controls.usesSecureFunctions" href="#pytm.Controls.usesSecureFunctions">usesSecureFunctions</a></code></li>
-<li><code><a title="pytm.Controls.usesStrongSessionIdentifiers" href="#pytm.Controls.usesStrongSessionIdentifiers">usesStrongSessionIdentifiers</a></code></li>
-<li><code><a title="pytm.Controls.usesVPN" href="#pytm.Controls.usesVPN">usesVPN</a></code></li>
-<li><code><a title="pytm.Controls.validatesContentType" href="#pytm.Controls.validatesContentType">validatesContentType</a></code></li>
-<li><code><a title="pytm.Controls.validatesHeaders" href="#pytm.Controls.validatesHeaders">validatesHeaders</a></code></li>
-<li><code><a title="pytm.Controls.validatesInput" href="#pytm.Controls.validatesInput">validatesInput</a></code></li>
-<li><code><a title="pytm.Controls.verifySessionIdentifiers" href="#pytm.Controls.verifySessionIdentifiers">verifySessionIdentifiers</a></code></li>
 </ul>
 </li>
 <li>
@@ -5608,23 +4170,18 @@ to a boolean True or False</p></div>
 <li>
 <h4><code><a title="pytm.Dataflow" href="#pytm.Dataflow">Dataflow</a></code></h4>
 <ul class="">
-<li><code><a title="pytm.Dataflow.authenticatedWith" href="#pytm.Dataflow.authenticatedWith">authenticatedWith</a></code></li>
-<li><code><a title="pytm.Dataflow.authenticatesDestination" href="#pytm.Dataflow.authenticatesDestination">authenticatesDestination</a></code></li>
-<li><code><a title="pytm.Dataflow.authorizesSource" href="#pytm.Dataflow.authorizesSource">authorizesSource</a></code></li>
-<li><code><a title="pytm.Dataflow.checksDestinationRevocation" href="#pytm.Dataflow.checksDestinationRevocation">checksDestinationRevocation</a></code></li>
 <li><code><a title="pytm.Dataflow.data" href="#pytm.Dataflow.data">data</a></code></li>
 <li><code><a title="pytm.Dataflow.display_name" href="#pytm.Dataflow.display_name">display_name</a></code></li>
 <li><code><a title="pytm.Dataflow.dstPort" href="#pytm.Dataflow.dstPort">dstPort</a></code></li>
 <li><code><a title="pytm.Dataflow.hasDataLeaks" href="#pytm.Dataflow.hasDataLeaks">hasDataLeaks</a></code></li>
-<li><code><a title="pytm.Dataflow.implementsAuthenticationScheme" href="#pytm.Dataflow.implementsAuthenticationScheme">implementsAuthenticationScheme</a></code></li>
 <li><code><a title="pytm.Dataflow.implementsCommunicationProtocol" href="#pytm.Dataflow.implementsCommunicationProtocol">implementsCommunicationProtocol</a></code></li>
-<li><code><a title="pytm.Dataflow.isEncrypted" href="#pytm.Dataflow.isEncrypted">isEncrypted</a></code></li>
 <li><code><a title="pytm.Dataflow.isResponse" href="#pytm.Dataflow.isResponse">isResponse</a></code></li>
 <li><code><a title="pytm.Dataflow.note" href="#pytm.Dataflow.note">note</a></code></li>
 <li><code><a title="pytm.Dataflow.order" href="#pytm.Dataflow.order">order</a></code></li>
 <li><code><a title="pytm.Dataflow.protocol" href="#pytm.Dataflow.protocol">protocol</a></code></li>
 <li><code><a title="pytm.Dataflow.response" href="#pytm.Dataflow.response">response</a></code></li>
 <li><code><a title="pytm.Dataflow.responseTo" href="#pytm.Dataflow.responseTo">responseTo</a></code></li>
+<li><code><a title="pytm.Dataflow.severity" href="#pytm.Dataflow.severity">severity</a></code></li>
 <li><code><a title="pytm.Dataflow.sink" href="#pytm.Dataflow.sink">sink</a></code></li>
 <li><code><a title="pytm.Dataflow.source" href="#pytm.Dataflow.source">source</a></code></li>
 <li><code><a title="pytm.Dataflow.srcPort" href="#pytm.Dataflow.srcPort">srcPort</a></code></li>
@@ -5635,22 +4192,14 @@ to a boolean True or False</p></div>
 </li>
 <li>
 <h4><code><a title="pytm.Datastore" href="#pytm.Datastore">Datastore</a></code></h4>
-<ul class="">
-<li><code><a title="pytm.Datastore.handlesInterruptions" href="#pytm.Datastore.handlesInterruptions">handlesInterruptions</a></code></li>
-<li><code><a title="pytm.Datastore.handlesResourceConsumption" href="#pytm.Datastore.handlesResourceConsumption">handlesResourceConsumption</a></code></li>
+<ul class="two-column">
 <li><code><a title="pytm.Datastore.hasWriteAccess" href="#pytm.Datastore.hasWriteAccess">hasWriteAccess</a></code></li>
-<li><code><a title="pytm.Datastore.implementsPOLP" href="#pytm.Datastore.implementsPOLP">implementsPOLP</a></code></li>
-<li><code><a title="pytm.Datastore.isEncryptedAtRest" href="#pytm.Datastore.isEncryptedAtRest">isEncryptedAtRest</a></code></li>
-<li><code><a title="pytm.Datastore.isResilient" href="#pytm.Datastore.isResilient">isResilient</a></code></li>
 <li><code><a title="pytm.Datastore.isSQL" href="#pytm.Datastore.isSQL">isSQL</a></code></li>
 <li><code><a title="pytm.Datastore.isShared" href="#pytm.Datastore.isShared">isShared</a></code></li>
 <li><code><a title="pytm.Datastore.onRDS" href="#pytm.Datastore.onRDS">onRDS</a></code></li>
-<li><code><a title="pytm.Datastore.providesConfidentiality" href="#pytm.Datastore.providesConfidentiality">providesConfidentiality</a></code></li>
-<li><code><a title="pytm.Datastore.providesIntegrity" href="#pytm.Datastore.providesIntegrity">providesIntegrity</a></code></li>
 <li><code><a title="pytm.Datastore.storesLogData" href="#pytm.Datastore.storesLogData">storesLogData</a></code></li>
 <li><code><a title="pytm.Datastore.storesPII" href="#pytm.Datastore.storesPII">storesPII</a></code></li>
 <li><code><a title="pytm.Datastore.storesSensitiveData" href="#pytm.Datastore.storesSensitiveData">storesSensitiveData</a></code></li>
-<li><code><a title="pytm.Datastore.usesEncryptionAlgorithm" href="#pytm.Datastore.usesEncryptionAlgorithm">usesEncryptionAlgorithm</a></code></li>
 <li><code><a title="pytm.Datastore.type" href="#pytm.Datastore.type">type</a></code></li>
 </ul>
 </li>
@@ -5668,6 +4217,7 @@ to a boolean True or False</p></div>
 <li>
 <h4><code><a title="pytm.Element" href="#pytm.Element">Element</a></code></h4>
 <ul class="two-column">
+<li><code><a title="pytm.Element.assumptions" href="#pytm.Element.assumptions">assumptions</a></code></li>
 <li><code><a title="pytm.Element.checkTLSVersion" href="#pytm.Element.checkTLSVersion">checkTLSVersion</a></code></li>
 <li><code><a title="pytm.Element.controls" href="#pytm.Element.controls">controls</a></code></li>
 <li><code><a title="pytm.Element.crosses" href="#pytm.Element.crosses">crosses</a></code></li>
@@ -5685,6 +4235,7 @@ to a boolean True or False</p></div>
 <li><code><a title="pytm.Element.name" href="#pytm.Element.name">name</a></code></li>
 <li><code><a title="pytm.Element.oneOf" href="#pytm.Element.oneOf">oneOf</a></code></li>
 <li><code><a title="pytm.Element.overrides" href="#pytm.Element.overrides">overrides</a></code></li>
+<li><code><a title="pytm.Element.severity" href="#pytm.Element.severity">severity</a></code></li>
 <li><code><a title="pytm.Element.sourceFiles" href="#pytm.Element.sourceFiles">sourceFiles</a></code></li>
 </ul>
 </li>
@@ -5697,6 +4248,7 @@ to a boolean True or False</p></div>
 <li>
 <h4><code><a title="pytm.Finding" href="#pytm.Finding">Finding</a></code></h4>
 <ul class="two-column">
+<li><code><a title="pytm.Finding.assumption" href="#pytm.Finding.assumption">assumption</a></code></li>
 <li><code><a title="pytm.Finding.condition" href="#pytm.Finding.condition">condition</a></code></li>
 <li><code><a title="pytm.Finding.cvss" href="#pytm.Finding.cvss">cvss</a></code></li>
 <li><code><a title="pytm.Finding.description" href="#pytm.Finding.description">description</a></code></li>
@@ -5738,50 +4290,19 @@ to a boolean True or False</p></div>
 <ul class="">
 <li><code><a title="pytm.Process.allowsClientSideScripting" href="#pytm.Process.allowsClientSideScripting">allowsClientSideScripting</a></code></li>
 <li><code><a title="pytm.Process.codeType" href="#pytm.Process.codeType">codeType</a></code></li>
-<li><code><a title="pytm.Process.disablesiFrames" href="#pytm.Process.disablesiFrames">disablesiFrames</a></code></li>
-<li><code><a title="pytm.Process.encryptsCookies" href="#pytm.Process.encryptsCookies">encryptsCookies</a></code></li>
-<li><code><a title="pytm.Process.encryptsSessionData" href="#pytm.Process.encryptsSessionData">encryptsSessionData</a></code></li>
 <li><code><a title="pytm.Process.environment" href="#pytm.Process.environment">environment</a></code></li>
-<li><code><a title="pytm.Process.handlesCrashes" href="#pytm.Process.handlesCrashes">handlesCrashes</a></code></li>
-<li><code><a title="pytm.Process.handlesInterruptions" href="#pytm.Process.handlesInterruptions">handlesInterruptions</a></code></li>
-<li><code><a title="pytm.Process.handlesResourceConsumption" href="#pytm.Process.handlesResourceConsumption">handlesResourceConsumption</a></code></li>
 <li><code><a title="pytm.Process.implementsAPI" href="#pytm.Process.implementsAPI">implementsAPI</a></code></li>
-<li><code><a title="pytm.Process.implementsCSRFToken" href="#pytm.Process.implementsCSRFToken">implementsCSRFToken</a></code></li>
 <li><code><a title="pytm.Process.implementsCommunicationProtocol" href="#pytm.Process.implementsCommunicationProtocol">implementsCommunicationProtocol</a></code></li>
-<li><code><a title="pytm.Process.implementsPOLP" href="#pytm.Process.implementsPOLP">implementsPOLP</a></code></li>
-<li><code><a title="pytm.Process.isResilient" href="#pytm.Process.isResilient">isResilient</a></code></li>
-<li><code><a title="pytm.Process.providesConfidentiality" href="#pytm.Process.providesConfidentiality">providesConfidentiality</a></code></li>
-<li><code><a title="pytm.Process.providesIntegrity" href="#pytm.Process.providesIntegrity">providesIntegrity</a></code></li>
 <li><code><a title="pytm.Process.tracksExecutionFlow" href="#pytm.Process.tracksExecutionFlow">tracksExecutionFlow</a></code></li>
-<li><code><a title="pytm.Process.usesMFA" href="#pytm.Process.usesMFA">usesMFA</a></code></li>
-<li><code><a title="pytm.Process.usesParameterizedInput" href="#pytm.Process.usesParameterizedInput">usesParameterizedInput</a></code></li>
-<li><code><a title="pytm.Process.usesSecureFunctions" href="#pytm.Process.usesSecureFunctions">usesSecureFunctions</a></code></li>
-<li><code><a title="pytm.Process.usesStrongSessionIdentifiers" href="#pytm.Process.usesStrongSessionIdentifiers">usesStrongSessionIdentifiers</a></code></li>
-<li><code><a title="pytm.Process.verifySessionIdentifiers" href="#pytm.Process.verifySessionIdentifiers">verifySessionIdentifiers</a></code></li>
 </ul>
 </li>
 <li>
 <h4><code><a title="pytm.Server" href="#pytm.Server">Server</a></code></h4>
 <ul class="">
-<li><code><a title="pytm.Server.disablesDTD" href="#pytm.Server.disablesDTD">disablesDTD</a></code></li>
-<li><code><a title="pytm.Server.encodesHeaders" href="#pytm.Server.encodesHeaders">encodesHeaders</a></code></li>
-<li><code><a title="pytm.Server.implementsCSRFToken" href="#pytm.Server.implementsCSRFToken">implementsCSRFToken</a></code></li>
-<li><code><a title="pytm.Server.implementsPOLP" href="#pytm.Server.implementsPOLP">implementsPOLP</a></code></li>
-<li><code><a title="pytm.Server.implementsServerSideValidation" href="#pytm.Server.implementsServerSideValidation">implementsServerSideValidation</a></code></li>
-<li><code><a title="pytm.Server.implementsStrictHTTPValidation" href="#pytm.Server.implementsStrictHTTPValidation">implementsStrictHTTPValidation</a></code></li>
-<li><code><a title="pytm.Server.invokesScriptFilters" href="#pytm.Server.invokesScriptFilters">invokesScriptFilters</a></code></li>
-<li><code><a title="pytm.Server.isResilient" href="#pytm.Server.isResilient">isResilient</a></code></li>
-<li><code><a title="pytm.Server.providesConfidentiality" href="#pytm.Server.providesConfidentiality">providesConfidentiality</a></code></li>
-<li><code><a title="pytm.Server.providesIntegrity" href="#pytm.Server.providesIntegrity">providesIntegrity</a></code></li>
 <li><code><a title="pytm.Server.usesCache" href="#pytm.Server.usesCache">usesCache</a></code></li>
-<li><code><a title="pytm.Server.usesCodeSigning" href="#pytm.Server.usesCodeSigning">usesCodeSigning</a></code></li>
-<li><code><a title="pytm.Server.usesEncryptionAlgorithm" href="#pytm.Server.usesEncryptionAlgorithm">usesEncryptionAlgorithm</a></code></li>
 <li><code><a title="pytm.Server.usesSessionTokens" href="#pytm.Server.usesSessionTokens">usesSessionTokens</a></code></li>
-<li><code><a title="pytm.Server.usesStrongSessionIdentifiers" href="#pytm.Server.usesStrongSessionIdentifiers">usesStrongSessionIdentifiers</a></code></li>
 <li><code><a title="pytm.Server.usesVPN" href="#pytm.Server.usesVPN">usesVPN</a></code></li>
 <li><code><a title="pytm.Server.usesXMLParser" href="#pytm.Server.usesXMLParser">usesXMLParser</a></code></li>
-<li><code><a title="pytm.Server.validatesContentType" href="#pytm.Server.validatesContentType">validatesContentType</a></code></li>
-<li><code><a title="pytm.Server.validatesHeaders" href="#pytm.Server.validatesHeaders">validatesHeaders</a></code></li>
 </ul>
 </li>
 <li>
@@ -5805,8 +4326,8 @@ to a boolean True or False</p></div>
 <ul class="two-column">
 <li><code><a title="pytm.TM.assumptions" href="#pytm.TM.assumptions">assumptions</a></code></li>
 <li><code><a title="pytm.TM.description" href="#pytm.TM.description">description</a></code></li>
+<li><code><a title="pytm.TM.excluded_findings" href="#pytm.TM.excluded_findings">excluded_findings</a></code></li>
 <li><code><a title="pytm.TM.findings" href="#pytm.TM.findings">findings</a></code></li>
-<li><code><a title="pytm.TM.get_table" href="#pytm.TM.get_table">get_table</a></code></li>
 <li><code><a title="pytm.TM.ignoreUnused" href="#pytm.TM.ignoreUnused">ignoreUnused</a></code></li>
 <li><code><a title="pytm.TM.isOrdered" href="#pytm.TM.isOrdered">isOrdered</a></code></li>
 <li><code><a title="pytm.TM.mergeResponses" href="#pytm.TM.mergeResponses">mergeResponses</a></code></li>
@@ -5829,7 +4350,9 @@ to a boolean True or False</p></div>
 <li><code><a title="pytm.Threat.details" href="#pytm.Threat.details">details</a></code></li>
 <li><code><a title="pytm.Threat.example" href="#pytm.Threat.example">example</a></code></li>
 <li><code><a title="pytm.Threat.id" href="#pytm.Threat.id">id</a></code></li>
+<li><code><a title="pytm.Threat.likelihood" href="#pytm.Threat.likelihood">likelihood</a></code></li>
 <li><code><a title="pytm.Threat.mitigations" href="#pytm.Threat.mitigations">mitigations</a></code></li>
+<li><code><a title="pytm.Threat.prerequisites" href="#pytm.Threat.prerequisites">prerequisites</a></code></li>
 <li><code><a title="pytm.Threat.references" href="#pytm.Threat.references">references</a></code></li>
 <li><code><a title="pytm.Threat.severity" href="#pytm.Threat.severity">severity</a></code></li>
 <li><code><a title="pytm.Threat.target" href="#pytm.Threat.target">target</a></code></li>

--- a/docs/pytm/index.html
+++ b/docs/pytm/index.html
@@ -320,7 +320,7 @@ __pdoc__ = pdoc_overrides()</code></pre>
 <span>(</span><span>name, **kwargs)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Assumption implemented by/on an Element.
+<div class="desc"><p>Assumption used by an Element.
 Used to exclude threats on a per-element basis.</p></div>
 <details class="source">
 <summary>
@@ -328,7 +328,7 @@ Used to exclude threats on a per-element basis.</p></div>
 </summary>
 <pre><code class="python">class Assumption:
     &#34;&#34;&#34;
-    Assumption implemented by/on an Element.
+    Assumption used by an Element.
     Used to exclude threats on a per-element basis.
     &#34;&#34;&#34;
     name = varString(&#34;&#34;, required=True)
@@ -3027,7 +3027,7 @@ with same properties, except name and notes&#34;&#34;&#34;,
         findings = []
         excluded_findings = []
         elements = defaultdict(list)
-        for e in TM._elements:  # type: Element
+        for e in TM._elements:
             if not e.inScope:
                 continue
 
@@ -3041,7 +3041,7 @@ with same properties, except name and notes&#34;&#34;&#34;,
             except AttributeError:
                 pass
 
-            for t in TM._threats:  # type: Threat
+            for t in TM._threats:
                 if not t.apply(e) and t.id not in override_ids:
                     continue
 
@@ -3714,7 +3714,7 @@ with same properties, except name and notes</p></div>
     findings = []
     excluded_findings = []
     elements = defaultdict(list)
-    for e in TM._elements:  # type: Element
+    for e in TM._elements:
         if not e.inScope:
             continue
 
@@ -3728,7 +3728,7 @@ with same properties, except name and notes</p></div>
         except AttributeError:
             pass
 
-        for t in TM._threats:  # type: Threat
+        for t in TM._threats:
             if not t.apply(e) and t.id not in override_ids:
                 continue
 

--- a/docs/pytm/report_util.html
+++ b/docs/pytm/report_util.html
@@ -1,0 +1,241 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
+<title>pytm.report_util API documentation</title>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>pytm.report_util</code></h1>
+</header>
+<section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ReportUtils:
+    @staticmethod
+    def getParentName(element):
+        from pytm import Boundary
+        if (isinstance(element, Boundary)):
+            parent = element.inBoundary
+            if (parent is not None):
+                return parent.name
+            else:
+                return str(&#34;&#34;)
+        else:
+            return &#34;ERROR: getParentName method is not valid for &#34; + element.__class__.__name__
+
+
+    @staticmethod
+    def getNamesOfParents(element):
+        from pytm import Boundary
+        if (isinstance(element, Boundary)):
+            parents = [p.name for p in element.parents()] 
+            return parents 
+        else:
+            return &#34;ERROR: getNamesOfParents method is not valid for &#34; + element.__class__.__name__
+
+    @staticmethod
+    def getFindingCount(element):
+        from pytm import Element
+        if (isinstance(element, Element)):
+            return str(len(list(element.findings)))
+        else:
+            return &#34;ERROR: getFindingCount method is not valid for &#34; + element.__class__.__name__
+
+    @staticmethod
+    def getElementType(element):
+        from pytm import Element
+        if (isinstance(element, Element)):
+            return str(element.__class__.__name__)
+        else:
+            return &#34;ERROR: getElementType method is not valid for &#34; + element.__class__.__name__</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="pytm.report_util.ReportUtils"><code class="flex name class">
+<span>class <span class="ident">ReportUtils</span></span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class ReportUtils:
+    @staticmethod
+    def getParentName(element):
+        from pytm import Boundary
+        if (isinstance(element, Boundary)):
+            parent = element.inBoundary
+            if (parent is not None):
+                return parent.name
+            else:
+                return str(&#34;&#34;)
+        else:
+            return &#34;ERROR: getParentName method is not valid for &#34; + element.__class__.__name__
+
+
+    @staticmethod
+    def getNamesOfParents(element):
+        from pytm import Boundary
+        if (isinstance(element, Boundary)):
+            parents = [p.name for p in element.parents()] 
+            return parents 
+        else:
+            return &#34;ERROR: getNamesOfParents method is not valid for &#34; + element.__class__.__name__
+
+    @staticmethod
+    def getFindingCount(element):
+        from pytm import Element
+        if (isinstance(element, Element)):
+            return str(len(list(element.findings)))
+        else:
+            return &#34;ERROR: getFindingCount method is not valid for &#34; + element.__class__.__name__
+
+    @staticmethod
+    def getElementType(element):
+        from pytm import Element
+        if (isinstance(element, Element)):
+            return str(element.__class__.__name__)
+        else:
+            return &#34;ERROR: getElementType method is not valid for &#34; + element.__class__.__name__</code></pre>
+</details>
+<h3>Static methods</h3>
+<dl>
+<dt id="pytm.report_util.ReportUtils.getElementType"><code class="name flex">
+<span>def <span class="ident">getElementType</span></span>(<span>element)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def getElementType(element):
+    from pytm import Element
+    if (isinstance(element, Element)):
+        return str(element.__class__.__name__)
+    else:
+        return &#34;ERROR: getElementType method is not valid for &#34; + element.__class__.__name__</code></pre>
+</details>
+</dd>
+<dt id="pytm.report_util.ReportUtils.getFindingCount"><code class="name flex">
+<span>def <span class="ident">getFindingCount</span></span>(<span>element)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def getFindingCount(element):
+    from pytm import Element
+    if (isinstance(element, Element)):
+        return str(len(list(element.findings)))
+    else:
+        return &#34;ERROR: getFindingCount method is not valid for &#34; + element.__class__.__name__</code></pre>
+</details>
+</dd>
+<dt id="pytm.report_util.ReportUtils.getNamesOfParents"><code class="name flex">
+<span>def <span class="ident">getNamesOfParents</span></span>(<span>element)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def getNamesOfParents(element):
+    from pytm import Boundary
+    if (isinstance(element, Boundary)):
+        parents = [p.name for p in element.parents()] 
+        return parents 
+    else:
+        return &#34;ERROR: getNamesOfParents method is not valid for &#34; + element.__class__.__name__</code></pre>
+</details>
+</dd>
+<dt id="pytm.report_util.ReportUtils.getParentName"><code class="name flex">
+<span>def <span class="ident">getParentName</span></span>(<span>element)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def getParentName(element):
+    from pytm import Boundary
+    if (isinstance(element, Boundary)):
+        parent = element.inBoundary
+        if (parent is not None):
+            return parent.name
+        else:
+            return str(&#34;&#34;)
+    else:
+        return &#34;ERROR: getParentName method is not valid for &#34; + element.__class__.__name__</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="pytm" href="index.html">pytm</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="pytm.report_util.ReportUtils" href="#pytm.report_util.ReportUtils">ReportUtils</a></code></h4>
+<ul class="">
+<li><code><a title="pytm.report_util.ReportUtils.getElementType" href="#pytm.report_util.ReportUtils.getElementType">getElementType</a></code></li>
+<li><code><a title="pytm.report_util.ReportUtils.getFindingCount" href="#pytm.report_util.ReportUtils.getFindingCount">getFindingCount</a></code></li>
+<li><code><a title="pytm.report_util.ReportUtils.getNamesOfParents" href="#pytm.report_util.ReportUtils.getNamesOfParents">getNamesOfParents</a></code></li>
+<li><code><a title="pytm.report_util.ReportUtils.getParentName" href="#pytm.report_util.ReportUtils.getParentName">getParentName</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/threats.md
+++ b/docs/threats.md
@@ -20,7 +20,7 @@ This attack pattern involves causing a buffer overflow through manipulation of e
   <dd>https://capec.mitre.org/data/definitions/10.html, CVE-1999-0906, CVE-1999-0046, http://cwe.mitre.org/data/definitions/120.html, http://cwe.mitre.org/data/definitions/119.html, http://cwe.mitre.org/data/definitions/680.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.usesEnvironmentVariables is True and target.sanitizesInput is False and target.checksInputBounds is False</dd>
+  <dd>target.usesEnvironmentVariables is True and target.controls.sanitizesInput is False and target.controls.checksInputBounds is False</dd>
 </dl>
 
 
@@ -46,7 +46,7 @@ Buffer Overflow attacks target improper or missing bounds checking on buffer ope
   <dd>https://capec.mitre.org/data/definitions/100.html, http://cwe.mitre.org/data/definitions/120.html, http://cwe.mitre.org/data/definitions/119.html, http://cwe.mitre.org/data/definitions/680.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.checksInputBounds is False</dd>
+  <dd>target.controls.checksInputBounds is False</dd>
 </dl>
 
 
@@ -72,7 +72,7 @@ An attacker can use Server Side Include (SSI) Injection to send code to a web ap
   <dd>https://capec.mitre.org/data/definitions/101.html, http://cwe.mitre.org/data/definitions/97.html, http://cwe.mitre.org/data/definitions/74.html, http://cwe.mitre.org/data/definitions/20.html, http://cwe.mitre.org/data/definitions/713.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.sanitizesInput is False or target.encodesOutput is False</dd>
+  <dd>target.controls.sanitizesInput is False or target.controls.encodesOutput is False</dd>
 </dl>
 
 
@@ -124,7 +124,7 @@ HTTP Request Splitting (also known as HTTP Request Smuggling) is an attack patte
   <dd>https://capec.mitre.org/data/definitions/105.html, http://cwe.mitre.org/data/definitions/436.html, http://cwe.mitre.org/data/definitions/444.html</dd>
 
   <dt>Condition</dt>
-  <dd>(target.validatesInput is False or target.validatesHeaders is False) and target.protocol =='HTTP'</dd>
+  <dd>(target.controls.validatesInput is False or target.controls.validatesHeaders is False) and target.protocol =='HTTP'</dd>
 </dl>
 
 
@@ -150,7 +150,7 @@ Cross Site Tracing (XST) enables an adversary to steal the victim's session cook
   <dd>https://capec.mitre.org/data/definitions/107.html, http://cwe.mitre.org/data/definitions/693.html, http://cwe.mitre.org/data/definitions/648.html</dd>
 
   <dt>Condition</dt>
-  <dd>(target.protocol == 'HTTP' and target.usesSessionTokens is True) and (target.sanitizesInput is False or target.validatesInput is False)</dd>
+  <dd>(target.protocol == 'HTTP' and target.usesSessionTokens is True) and (target.controls.sanitizesInput is False or target.controls.validatesInput is False)</dd>
 </dl>
 
 
@@ -176,7 +176,7 @@ An attacker uses standard SQL injection methods to inject data into the command 
   <dd>https://capec.mitre.org/data/definitions/108.html, http://cwe.mitre.org/data/definitions/89.html, http://cwe.mitre.org/data/definitions/74.html, http://cwe.mitre.org/data/definitions/20.html, http://cwe.mitre.org/data/definitions/78.html, http://cwe.mitre.org/data/definitions/114.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False</dd>
+  <dd>target.controls.validatesInput is False</dd>
 </dl>
 
 
@@ -202,7 +202,7 @@ An attacker modifies the parameters of the SOAP message that is sent from the se
   <dd>https://capec.mitre.org/data/definitions/110.html, http://cwe.mitre.org/data/definitions/89.html, http://cwe.mitre.org/data/definitions/20.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.protocol == 'SOAP' and (target.sanitizesInput is False or target.validatesInput is False)</dd>
+  <dd>target.protocol == 'SOAP' and (target.controls.sanitizesInput is False or target.controls.validatesInput is False)</dd>
 </dl>
 
 
@@ -228,7 +228,7 @@ An attacker targets a system that uses JavaScript Object Notation (JSON) as a tr
   <dd>https://capec.mitre.org/data/definitions/111.html, http://cwe.mitre.org/data/definitions/345.html, http://cwe.mitre.org/data/definitions/346.html, http://cwe.mitre.org/data/definitions/352.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.implementsNonce is False and any(d.format == 'JSON' for d in target.data)</dd>
+  <dd>target.controls.implementsNonce is False and any(d.format == 'JSON' for d in target.data)</dd>
 </dl>
 
 
@@ -254,7 +254,7 @@ An adversary manipulates the use or processing of an Application Programming Int
   <dd>https://capec.mitre.org/data/definitions/113.html, http://cwe.mitre.org/data/definitions/227.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.implementsAPI is True and (target.validatesInput is False or target.sanitizesInput is False)</dd>
+  <dd>target.implementsAPI is True and (target.controls.validatesInput is False or target.controls.sanitizesInput is False)</dd>
 </dl>
 
 
@@ -280,7 +280,7 @@ An attacker obtains unauthorized access to an application, service or device eit
   <dd>https://capec.mitre.org/data/definitions/114.html, http://cwe.mitre.org/data/definitions/287.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.authenticatesSource is False</dd>
+  <dd>target.controls.authenticatesSource is False</dd>
 </dl>
 
 
@@ -306,7 +306,7 @@ An adversary actively probes the target in a manner that is designed to solicit 
   <dd>https://capec.mitre.org/data/definitions/116.html, http://cwe.mitre.org/data/definitions/200.html</dd>
 
   <dt>Condition</dt>
-  <dd>(target.sanitizesInput is False or target.validatesInput is False) or target.encodesOutput is False</dd>
+  <dd>(target.controls.sanitizesInput is False or target.controls.validatesInput is False) or target.controls.encodesOutput is False</dd>
 </dl>
 
 
@@ -332,7 +332,7 @@ An adversary monitors data streams to or from the target for information gatheri
   <dd>https://capec.mitre.org/data/definitions/117.html, http://cwe.mitre.org/data/definitions/319.html, https://cwe.mitre.org/data/definitions/299.html</dd>
 
   <dt>Condition</dt>
-  <dd>not target.isEncrypted or (target.source.inScope and not target.isResponse and (not target.authenticatesDestination or not target.checksDestinationRevocation)) or target.tlsVersion < target.sink.minTLSVersion</dd>
+  <dd>not target.controls.isEncrypted or (target.source.inScope and not target.isResponse and (not target.controls.authenticatesDestination or not target.controls.checksDestinationRevocation)) or target.tlsVersion < target.sink.minTLSVersion</dd>
 </dl>
 
 
@@ -358,7 +358,7 @@ The adversary utilizes a repeating of the encoding process for a set of characte
   <dd>https://capec.mitre.org/data/definitions/120.html, http://cwe.mitre.org/data/definitions/173.html, http://cwe.mitre.org/data/definitions/177.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False or target.sanitizesInput is False</dd>
+  <dd>target.controls.validatesInput is False or target.controls.sanitizesInput is False</dd>
 </dl>
 
 
@@ -410,7 +410,7 @@ An adversary is able to exploit features of the target that should be reserved f
   <dd>https://capec.mitre.org/data/definitions/122.html, http://cwe.mitre.org/data/definitions/732.html, http://cwe.mitre.org/data/definitions/269.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.hasAccessControl is False or target.authorizesSource is False</dd>
+  <dd>target.controls.hasAccessControl is False or target.controls.authorizesSource is False</dd>
 </dl>
 
 
@@ -436,7 +436,7 @@ An adversary manipulates an application's interaction with a buffer in an attemp
   <dd>https://capec.mitre.org/data/definitions/123.html, http://cwe.mitre.org/data/definitions/119.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.usesSecureFunctions is False</dd>
+  <dd>target.controls.usesSecureFunctions is False</dd>
 </dl>
 
 
@@ -488,7 +488,7 @@ An adversary consumes the resources of a target by rapidly engaging in a large n
   <dd>https://capec.mitre.org/data/definitions/125.html, http://cwe.mitre.org/data/definitions/404.html, http://cwe.mitre.org/data/definitions/770.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.handlesResourceConsumption is False or target.isResilient is False</dd>
+  <dd>target.controls.handlesResourceConsumption is False or target.controls.isResilient is False</dd>
 </dl>
 
 
@@ -514,7 +514,7 @@ An adversary uses path manipulation methods to exploit insufficient input valida
   <dd>https://capec.mitre.org/data/definitions/126.html, http://cwe.mitre.org/data/definitions/22.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False and target.sanitizesInput is False</dd>
+  <dd>target.controls.validatesInput is False and target.controls.sanitizesInput is False</dd>
 </dl>
 
 
@@ -540,7 +540,7 @@ The attacker directly or indirectly modifies environment variables used by or co
   <dd>https://capec.mitre.org/data/definitions/13.html, http://cwe.mitre.org/data/definitions/353.html, http://cwe.mitre.org/data/definitions/15.html, http://cwe.mitre.org/data/definitions/74.html, http://cwe.mitre.org/data/definitions/302.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.usesEnvironmentVariables is True and (target.implementsAuthenticationScheme is False or target.validatesInput is False or target.authorizesSource is False)</dd>
+  <dd>target.usesEnvironmentVariables is True and (target.controls.implementsAuthenticationScheme is False or target.controls.validatesInput is False or target.controls.authorizesSource is False)</dd>
 </dl>
 
 
@@ -566,7 +566,7 @@ An adversary causes the target to allocate excessive resources to servicing the 
   <dd>https://capec.mitre.org/data/definitions/130.html, http://cwe.mitre.org/data/definitions/770.html, http://cwe.mitre.org/data/definitions/404.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.handlesResourceConsumption is False</dd>
+  <dd>target.controls.handlesResourceConsumption is False</dd>
 </dl>
 
 
@@ -618,7 +618,7 @@ An adversary includes formatting characters in a string input field on the targe
   <dd>https://capec.mitre.org/data/definitions/135.html, http://cwe.mitre.org/data/definitions/134.html, http://cwe.mitre.org/data/definitions/133.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False or target.sanitizesInput is False</dd>
+  <dd>target.controls.validatesInput is False or target.controls.sanitizesInput is False</dd>
 </dl>
 
 
@@ -644,7 +644,7 @@ An attacker manipulates or crafts an LDAP query for the purpose of undermining t
   <dd>https://capec.mitre.org/data/definitions/136.html, http://cwe.mitre.org/data/definitions/77.html, http://cwe.mitre.org/data/definitions/90.html, http://cwe.mitre.org/data/definitions/20.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False</dd>
+  <dd>target.controls.validatesInput is False</dd>
 </dl>
 
 
@@ -670,7 +670,7 @@ An adversary manipulates the content of request parameters for the purpose of un
   <dd>https://capec.mitre.org/data/definitions/137.html, http://cwe.mitre.org/data/definitions/88.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False</dd>
+  <dd>target.controls.validatesInput is False</dd>
 </dl>
 
 
@@ -696,7 +696,7 @@ An attacker exploits a weakness in input validation on the target by supplying a
   <dd>https://capec.mitre.org/data/definitions/139.html, http://cwe.mitre.org/data/definitions/23.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False or target.sanitizesInput is False</dd>
+  <dd>target.controls.validatesInput is False or target.controls.sanitizesInput is False</dd>
 </dl>
 
 
@@ -722,7 +722,7 @@ This type of attack exploits a buffer overflow vulnerability in targeted client 
   <dd>https://capec.mitre.org/data/definitions/14.html, http://cwe.mitre.org/data/definitions/74.html, http://cwe.mitre.org/data/definitions/353.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.checksInputBounds is False and target.validatesInput is False</dd>
+  <dd>target.controls.checksInputBounds is False and target.controls.validatesInput is False</dd>
 </dl>
 
 
@@ -748,7 +748,7 @@ An adversary corrupts or modifies the content of XML schema information passed b
   <dd>https://capec.mitre.org/data/definitions/146.html, http://cwe.mitre.org/data/definitions/15.html, http://cwe.mitre.org/data/definitions/472.html</dd>
 
   <dt>Condition</dt>
-  <dd>any(d.format == 'XML' for d in target.data) and target.authorizesSource is False</dd>
+  <dd>any(d.format == 'XML' for d in target.data) and target.controls.authorizesSource is False</dd>
 </dl>
 
 
@@ -800,7 +800,7 @@ An adversary modifies content to make it contain something other than what the o
   <dd>https://capec.mitre.org/data/definitions/148.html, http://cwe.mitre.org/data/definitions/345.html, https://cwe.mitre.org/data/definitions/299.html</dd>
 
   <dt>Condition</dt>
-  <dd>((not target.source.providesIntegrity or not target.sink.providesIntegrity) and not target.isEncrypted) or (target.source.inScope and not target.isResponse and (not target.authenticatesDestination or not target.checksDestinationRevocation))</dd>
+  <dd>((not target.source.controls.providesIntegrity or not target.sink.controls.providesIntegrity) and not target.controls.isEncrypted) or (target.source.inScope and not target.isResponse and (not target.controls.authenticatesDestination or not target.controls.checksDestinationRevocation))</dd>
 </dl>
 
 
@@ -826,7 +826,7 @@ An attack of this type exploits a programs' vulnerabilities that allows an attac
   <dd>https://capec.mitre.org/data/definitions/15.html, http://cwe.mitre.org/data/definitions/146.html, http://cwe.mitre.org/data/definitions/77.html, http://cwe.mitre.org/data/definitions/157.html, http://cwe.mitre.org/data/definitions/154.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False</dd>
+  <dd>target.controls.validatesInput is False</dd>
 </dl>
 
 
@@ -852,7 +852,7 @@ An attacker exploits a weakness in input validation by controlling the format, s
   <dd>https://capec.mitre.org/data/definitions/153.html, http://cwe.mitre.org/data/definitions/20.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False</dd>
+  <dd>target.controls.validatesInput is False</dd>
 </dl>
 
 
@@ -878,7 +878,7 @@ In this attack pattern, the adversary intercepts information transmitted between
   <dd>https://capec.mitre.org/data/definitions/157.html, http://cwe.mitre.org/data/definitions/311.html</dd>
 
   <dt>Condition</dt>
-  <dd>(target.protocol == 'HTTP' or target.isEncrypted is False) or target.usesVPN is False</dd>
+  <dd>(target.protocol == 'HTTP' or target.controls.isEncrypted is False) or target.usesVPN is False</dd>
 </dl>
 
 
@@ -904,7 +904,7 @@ An attacker tries each of the words in a dictionary as passwords to gain access 
   <dd>https://capec.mitre.org/data/definitions/16.html, http://cwe.mitre.org/data/definitions/521.html, http://cwe.mitre.org/data/definitions/262.html, http://cwe.mitre.org/data/definitions/263.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.implementsAuthenticationScheme is False</dd>
+  <dd>target.controls.implementsAuthenticationScheme is False</dd>
 </dl>
 
 
@@ -930,7 +930,7 @@ Some APIs support scripting instructions as arguments. Methods that take scripte
   <dd>https://capec.mitre.org/data/definitions/160.html, http://cwe.mitre.org/data/definitions/346.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.implementsAPI is True and target.validatesInput is False</dd>
+  <dd>target.implementsAPI is True and target.controls.validatesInput is False</dd>
 </dl>
 
 
@@ -982,7 +982,7 @@ An adversary engages in probing and exploration activities to identify constitue
   <dd>https://capec.mitre.org/data/definitions/169.html, http://cwe.mitre.org/data/definitions/200.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.isHardened is False</dd>
+  <dd>target.controls.isHardened is False</dd>
 </dl>
 
 
@@ -1008,7 +1008,7 @@ An attack of this type exploits a system's configuration that allows an attacker
   <dd>https://capec.mitre.org/data/definitions/17.html, http://cwe.mitre.org/data/definitions/732.html, http://cwe.mitre.org/data/definitions/272.html, http://cwe.mitre.org/data/definitions/270.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.isHardened is False or target.hasAccessControl is False</dd>
+  <dd>target.controls.isHardened is False or target.controls.hasAccessControl is False</dd>
 </dl>
 
 
@@ -1034,7 +1034,7 @@ An attacker sends a series of probes to a web application in order to elicit ver
   <dd>https://capec.mitre.org/data/definitions/170.html, http://cwe.mitre.org/data/definitions/497.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesHeaders is False or target.encodesOutput is False or target.isHardened is False</dd>
+  <dd>target.controls.validatesHeaders is False or target.controls.encodesOutput is False or target.controls.isHardened is False</dd>
 </dl>
 
 
@@ -1060,7 +1060,7 @@ This attack is a form of Cross-Site Scripting (XSS) where malicious scripts are 
   <dd>https://capec.mitre.org/data/definitions/18.html, http://cwe.mitre.org/data/definitions/80.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False or target.encodesOutput is False</dd>
+  <dd>target.controls.validatesInput is False or target.controls.encodesOutput is False</dd>
 </dl>
 
 
@@ -1074,7 +1074,7 @@ An attacker exploits a weakness in the configuration of access controls and is a
   <dd>Medium</dd>
 
   <dt>Prerequisites</dt>
-  <dd>The target must apply access controls, but incorrectly configure them. However, not all incorrect configurations can be exploited by an attacker. If the incorrect configuration applies too little security to some functionality, then the attacker may be able to exploit it if the access control would be the only thing preventing an attacker's access and it no longer does so. If the incorrect configuration applies too much security, it must prevent legitimate activity and the attacker must be able to force others to require this activity..</dd>
+  <dd>The target must apply access controls, but incorrectly configure them. However, not all incorrect configurations can be exploited by an attacker. If the incorrect configuration applies too little security to some functionality, then the attacker may be able to exploit it if the access control would be the only thing preventing an attacker's access and it no longer does so. If the incorrect configuration applies too much security, it must prevent legitimate activity and the attacker must be able to force others to require this activity.</dd>
 
   <dt>Example</dt>
   <dd>For example, an incorrectly configured Web server, may allow unauthorized access to it, thus threaten the security of the Web application.</dd>
@@ -1086,7 +1086,7 @@ An attacker exploits a weakness in the configuration of access controls and is a
   <dd>https://capec.mitre.org/data/definitions/180.html, http://cwe.mitre.org/data/definitions/732.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.hasAccessControl is False</dd>
+  <dd>target.controls.hasAccessControl is False</dd>
 </dl>
 
 
@@ -1112,7 +1112,7 @@ An attacker exploits weaknesses in input validation on IMAP/SMTP servers to exec
   <dd>https://capec.mitre.org/data/definitions/183.html, http://cwe.mitre.org/data/definitions/77.html</dd>
 
   <dt>Condition</dt>
-  <dd>(target.protocol == 'IMAP' or target.protocol == 'SMTP') and target.sanitizesInput is False</dd>
+  <dd>(target.protocol == 'IMAP' or target.protocol == 'SMTP') and target.controls.sanitizesInput is False</dd>
 </dl>
 
 
@@ -1164,7 +1164,7 @@ An attack of this type exploits a programs' vulnerabilities that are brought on 
   <dd>https://capec.mitre.org/data/definitions/19.html, http://cwe.mitre.org/data/definitions/284.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False or target.sanitizesInput is False or target.hasAccessControl is False</dd>
+  <dd>target.controls.validatesInput is False or target.controls.sanitizesInput is False or target.controls.hasAccessControl is False</dd>
 </dl>
 
 
@@ -1190,7 +1190,7 @@ In this pattern the adversary is able to load and execute arbitrary code remotel
   <dd>https://capec.mitre.org/data/definitions/193.html, http://cwe.mitre.org/data/definitions/98.html, http://cwe.mitre.org/data/definitions/80.html, http://cwe.mitre.org/data/definitions/714.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False</dd>
+  <dd>target.controls.validatesInput is False</dd>
 </dl>
 
 
@@ -1216,7 +1216,7 @@ A Principal Spoof is a form of Identity Spoofing where an adversary pretends to 
   <dd>https://capec.mitre.org/data/definitions/195.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.authenticatesSource is False</dd>
+  <dd>target.controls.authenticatesSource is False</dd>
 </dl>
 
 
@@ -1242,7 +1242,7 @@ An attacker creates a false but functional session credential in order to gain o
   <dd>https://capec.mitre.org/data/definitions/196.html, http://cwe.mitre.org/data/definitions/384.html, http://cwe.mitre.org/data/definitions/664.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.usesSessionTokens is True and target.implementsNonce is False</dd>
+  <dd>target.usesSessionTokens is True and target.controls.implementsNonce is False</dd>
 </dl>
 
 
@@ -1294,7 +1294,7 @@ An adversary distributes a link (or possibly some other query structure) with a 
   <dd>https://capec.mitre.org/data/definitions/198.html, http://cwe.mitre.org/data/definitions/81.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.encodesOutput is False or target.validatesInput is False or target.sanitizesInput is False</dd>
+  <dd>target.controls.encodesOutput is False or target.controls.validatesInput is False or target.controls.sanitizesInput is False</dd>
 </dl>
 
 
@@ -1320,7 +1320,7 @@ An adversary uses alternate forms of keywords or commands that result in the sam
   <dd>https://capec.mitre.org/data/definitions/199.html, http://cwe.mitre.org/data/definitions/87.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.sanitizesInput is False or target.validatesInput is False or target.encodesOutput is False</dd>
+  <dd>target.controls.sanitizesInput is False or target.controls.validatesInput is False or target.controls.encodesOutput is False</dd>
 </dl>
 
 
@@ -1346,7 +1346,7 @@ An attacker, armed with the cipher text and the encryption algorithm used, perfo
   <dd>https://capec.mitre.org/data/definitions/20.html, http://cwe.mitre.org/data/definitions/326.html, http://cwe.mitre.org/data/definitions/327.html, http://cwe.mitre.org/data/definitions/693.html, http://cwe.mitre.org/data/definitions/719.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.usesEncryptionAlgorithm != 'RSA' and target.usesEncryptionAlgorithm != 'AES'</dd>
+  <dd>target.controls.usesEncryptionAlgorithm != 'RSA' and target.controls.usesEncryptionAlgorithm != 'AES'</dd>
 </dl>
 
 
@@ -1372,7 +1372,7 @@ An adversary exploits a weakness in authorization in order to modify content wit
   <dd>https://capec.mitre.org/data/definitions/203.html, http://cwe.mitre.org/data/definitions/15.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.hasAccessControl is False</dd>
+  <dd>target.controls.hasAccessControl is False</dd>
 </dl>
 
 
@@ -1424,7 +1424,7 @@ An attacker removes or disables functionality on the client that the server assu
   <dd>http://cwe.mitre.org/data/definitions/602.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.providesIntegrity is False or target.usesCodeSigning is False</dd>
+  <dd>target.controls.providesIntegrity is False or target.controls.usesCodeSigning is False</dd>
 </dl>
 
 
@@ -1450,7 +1450,7 @@ An adversary creates a file with scripting content but where the specified MIME 
   <dd>http://cwe.mitre.org/data/definitions/79.html, http://cwe.mitre.org/data/definitions/20.html, http://cwe.mitre.org/data/definitions/646.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesContentType is False or target.invokesScriptFilters is False</dd>
+  <dd>target.controls.validatesContentType is False or target.controls.invokesScriptFilters is False</dd>
 </dl>
 
 
@@ -1476,7 +1476,7 @@ Attacks on session IDs and resource IDs take advantage of the fact that some sof
   <dd>https://capec.mitre.org/data/definitions/21.html, http://cwe.mitre.org/data/definitions/290.html, http://cwe.mitre.org/data/definitions/346.html, http://cwe.mitre.org/data/definitions/664.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.providesIntegrity is False or target.authenticatesSource is False or target.usesStrongSessionIdentifiers is False</dd>
+  <dd>target.controls.providesIntegrity is False or target.controls.authenticatesSource is False or target.controls.usesStrongSessionIdentifiers is False</dd>
 </dl>
 
 
@@ -1502,7 +1502,7 @@ An adversary leverages a legitimate capability of an application in such a way a
   <dd>https://capec.mitre.org/data/definitions/212.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.hasAccessControl is False or target.authorizesSource is False</dd>
+  <dd>target.controls.hasAccessControl is False or target.controls.authorizesSource is False</dd>
 </dl>
 
 
@@ -1528,7 +1528,7 @@ An attacker sends random, malformed, or otherwise unexpected messages to a targe
   <dd>https://capec.mitre.org/data/definitions/215.html, http://cwe.mitre.org/data/definitions/209.html, http://cwe.mitre.org/data/definitions/532.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.sanitizesInput is False or target.encodesOutput is False</dd>
+  <dd>target.controls.sanitizesInput is False or target.controls.encodesOutput is False</dd>
 </dl>
 
 
@@ -1554,7 +1554,7 @@ An adversary manipulates a setting or parameter on communications channel in ord
   <dd>https://capec.mitre.org/data/definitions/216.html</dd>
 
   <dt>Condition</dt>
-  <dd>(target.protocol != 'HTTPS' or target.usesVPN is False) and (target.implementsAuthenticationScheme is False or target.authorizesSource is False)</dd>
+  <dd>(target.protocol != 'HTTPS' or target.usesVPN is False) and (target.controls.implementsAuthenticationScheme is False or target.controls.authorizesSource is False)</dd>
 </dl>
 
 
@@ -1580,7 +1580,7 @@ An adversary takes advantage of incorrectly configured SSL communications that e
   <dd>https://capec.mitre.org/data/definitions/217.html, http://cwe.mitre.org/data/definitions/201.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.checkTLSVersion(target.inputs) and (not target.implementsAuthenticationScheme or not target.authorizesSource)</dd>
+  <dd>target.checkTLSVersion(target.inputs) and (not target.controls.implementsAuthenticationScheme or not target.controls.authorizesSource)</dd>
 </dl>
 
 
@@ -1632,7 +1632,7 @@ An attack of this type exploits vulnerabilities in client/server communication c
   <dd>https://capec.mitre.org/data/definitions/22.html, http://cwe.mitre.org/data/definitions/287.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.implementsServerSideValidation is False and (target.providesIntegrity is False or target.authorizesSource is False)</dd>
+  <dd>target.controls.implementsServerSideValidation is False and (target.controls.providesIntegrity is False or target.controls.authorizesSource is False)</dd>
 </dl>
 
 
@@ -1658,7 +1658,7 @@ An adversary takes advantage of weaknesses in the protocol by which a client and
   <dd>https://capec.mitre.org/data/definitions/220.html, http://cwe.mitre.org/data/definitions/757.html</dd>
 
   <dt>Condition</dt>
-  <dd>not target.isEncrypted or target.tlsVersion < target.sink.minTLSVersion</dd>
+  <dd>not target.controls.isEncrypted or target.tlsVersion < target.sink.minTLSVersion</dd>
 </dl>
 
 
@@ -1684,7 +1684,7 @@ This attack takes advantage of the entity replacement property of XML where the 
   <dd>https://capec.mitre.org/data/definitions/221.html, http://cwe.mitre.org/data/definitions/611.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.usesXMLParser is False or target.disablesDTD is False</dd>
+  <dd>target.usesXMLParser is False or target.controls.disablesDTD is False</dd>
 </dl>
 
 
@@ -1710,7 +1710,7 @@ In an iFrame overlay attack the victim is tricked into unknowingly initiating so
   <dd>https://capec.mitre.org/data/definitions/222.html, http://cwe.mitre.org/data/definitions/1021.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.disablesiFrames is False</dd>
+  <dd>target.controls.disablesiFrames is False</dd>
 </dl>
 
 
@@ -1736,7 +1736,7 @@ An attacker manipulates an existing credential in order to gain access to a targ
   <dd>https://capec.mitre.org/data/definitions/226.html, http://cwe.mitre.org/data/definitions/565.html, http://cwe.mitre.org/data/definitions/472.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.usesStrongSessionIdentifiers is False</dd>
+  <dd>target.controls.usesStrongSessionIdentifiers is False</dd>
 </dl>
 
 
@@ -1762,7 +1762,7 @@ An attacker injects malicious content into an application's DTD in an attempt to
   <dd>https://capec.mitre.org/data/definitions/228.html, http://cwe.mitre.org/data/definitions/829.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.usesXMLParser is False or target.disablesDTD is False</dd>
+  <dd>target.usesXMLParser is False or target.controls.disablesDTD is False</dd>
 </dl>
 
 
@@ -1788,7 +1788,7 @@ This attack exploits certain XML parsers which manage data in an inefficient man
   <dd>https://capec.mitre.org/data/definitions/229.html, http://cwe.mitre.org/data/definitions/770.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.usesXMLParser is False or target.disablesDTD is False</dd>
+  <dd>target.usesXMLParser is False or target.controls.disablesDTD is False</dd>
 </dl>
 
 
@@ -1814,7 +1814,7 @@ An attack of this type exploits the host's trust in executing remote content, in
   <dd>https://capec.mitre.org/data/definitions/23.html, http://cwe.mitre.org/data/definitions/20.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.hasAccessControl is False and (target.sanitizesInput is False or target.validatesInput is False)</dd>
+  <dd>target.controls.hasAccessControl is False and (target.controls.sanitizesInput is False or target.controls.validatesInput is False)</dd>
 </dl>
 
 
@@ -1840,7 +1840,7 @@ Applications often need to transform data in and out of the XML format by using 
   <dd>https://capec.mitre.org/data/definitions/230.html, http://cwe.mitre.org/data/definitions/112.html, http://cwe.mitre.org/data/definitions/770.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.usesXMLParser is True and (target.validatesInput is False or target.sanitizesInput is False)</dd>
+  <dd>target.usesXMLParser is True and (target.controls.validatesInput is False or target.controls.sanitizesInput is False)</dd>
 </dl>
 
 
@@ -1866,7 +1866,7 @@ An adversary exploits a weakness enabling them to elevate their privilege and pe
   <dd>https://capec.mitre.org/data/definitions/233.html, http://cwe.mitre.org/data/definitions/269.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.hasAccessControl is False or target.implementsPOLP is False</dd>
+  <dd>target.controls.hasAccessControl is False or target.controls.implementsPOLP is False</dd>
 </dl>
 
 
@@ -1892,7 +1892,7 @@ An attacker gains control of a process that is assigned elevated privileges in o
   <dd>https://capec.mitre.org/data/definitions/234.html, http://cwe.mitre.org/data/definitions/732.html, http://cwe.mitre.org/data/definitions/648.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.hasAccessControl is False or target.implementsPOLP is False</dd>
+  <dd>target.controls.hasAccessControl is False or target.controls.implementsPOLP is False</dd>
 </dl>
 
 
@@ -1918,7 +1918,7 @@ Attackers can sometimes hijack a privileged thread from the underlying system th
   <dd>https://capec.mitre.org/data/definitions/236.html, http://cwe.mitre.org/data/definitions/270.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.implementsPOLP is False and (target.usesEnvironmentVariables is True or target.validatesInput is False)</dd>
+  <dd>target.controls.implementsPOLP is False and (target.usesEnvironmentVariables is True or target.controls.validatesInput is False)</dd>
 </dl>
 
 
@@ -1944,7 +1944,7 @@ In this attack, the idea is to cause an active filter to fail by causing an over
   <dd>https://capec.mitre.org/data/definitions/24.html, http://cwe.mitre.org/data/definitions/120.html, http://cwe.mitre.org/data/definitions/680.html, http://cwe.mitre.org/data/definitions/20.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.checksInputBounds is False or target.validatesInput is False</dd>
+  <dd>target.controls.checksInputBounds is False or target.controls.validatesInput is False</dd>
 </dl>
 
 
@@ -1970,7 +1970,7 @@ An adversary exploits weaknesses in input validation by manipulating resource id
   <dd>https://capec.mitre.org/data/definitions/240.html, https://capec.mitre.org/data/definitions/240.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False or target.sanitizesInput is False</dd>
+  <dd>target.controls.validatesInput is False or target.controls.sanitizesInput is False</dd>
 </dl>
 
 
@@ -1996,7 +1996,7 @@ An adversary exploits a weakness in input validation on the target to inject new
   <dd>https://capec.mitre.org/data/definitions/242.html, http://cwe.mitre.org/data/definitions/94.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False or target.sanitizesInput is False</dd>
+  <dd>target.controls.validatesInput is False or target.controls.sanitizesInput is False</dd>
 </dl>
 
 
@@ -2022,7 +2022,7 @@ An adversary inserts commands to perform cross-site scripting (XSS) actions in H
   <dd>https://capec.mitre.org/data/definitions/243.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False or target.sanitizesInput is False</dd>
+  <dd>target.controls.validatesInput is False or target.controls.sanitizesInput is False</dd>
 </dl>
 
 
@@ -2048,7 +2048,7 @@ An attack of this type exploits the ability of most browsers to interpret data, 
   <dd>https://capec.mitre.org/data/definitions/244.html, http://cwe.mitre.org/data/definitions/83.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False or target.sanitizesInput is False or target.encodesOutput is False</dd>
+  <dd>target.controls.validatesInput is False or target.controls.sanitizesInput is False or target.controls.encodesOutput is False</dd>
 </dl>
 
 
@@ -2074,7 +2074,7 @@ The attacker bypasses input validation by using doubled characters in order to p
   <dd>https://capec.mitre.org/data/definitions/245.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False or target.sanitizesInput is False or target.encodesOutput is False</dd>
+  <dd>target.controls.validatesInput is False or target.controls.sanitizesInput is False or target.controls.encodesOutput is False</dd>
 </dl>
 
 
@@ -2100,7 +2100,7 @@ An adversary inserts invalid characters in identifiers to bypass application fil
   <dd>https://capec.mitre.org/data/definitions/247.html, https://cwe.mitre.org/data/definitions/86.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False or target.sanitizesInput is False</dd>
+  <dd>target.controls.validatesInput is False or target.controls.sanitizesInput is False</dd>
 </dl>
 
 
@@ -2126,7 +2126,7 @@ An adversary looking to execute a command of their choosing, injects new items i
   <dd>https://capec.mitre.org/data/definitions/248.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.usesParameterizedInput is False and (target.validatesInput is False or target.sanitizesInput is False)</dd>
+  <dd>target.controls.usesParameterizedInput is False and (target.controls.validatesInput is False or target.controls.sanitizesInput is False)</dd>
 </dl>
 
 
@@ -2152,7 +2152,7 @@ An attacker utilizes crafted XML user-controllable input to probe, attack, and i
   <dd>https://capec.mitre.org/data/definitions/250.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False or target.sanitizesInput is False or target.encodesOutput is False</dd>
+  <dd>target.controls.validatesInput is False or target.controls.sanitizesInput is False or target.controls.encodesOutput is False</dd>
 </dl>
 
 
@@ -2178,7 +2178,7 @@ The attacker forces an application to load arbitrary code files from a remote lo
   <dd>https://capec.mitre.org/data/definitions/253.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False or target.sanitizesInput is False</dd>
+  <dd>target.controls.validatesInput is False or target.controls.sanitizesInput is False</dd>
 </dl>
 
 
@@ -2204,7 +2204,7 @@ An attacker sends a SOAP request with an array whose actual length exceeds the l
   <dd>https://capec.mitre.org/data/definitions/256.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.checksInputBounds is False</dd>
+  <dd>target.controls.checksInputBounds is False</dd>
 </dl>
 
 
@@ -2230,7 +2230,7 @@ An adversary leverages the possibility to encode potentially harmful input or co
   <dd>https://capec.mitre.org/data/definitions/267.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False or target.sanitizesInput is False</dd>
+  <dd>target.controls.validatesInput is False or target.controls.sanitizesInput is False</dd>
 </dl>
 
 
@@ -2256,7 +2256,7 @@ The attacker injects, manipulates, deletes, or forges malicious log entries into
   <dd>https://capec.mitre.org/data/definitions/268.html, https://capec.mitre.org/data/definitions/93.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False or target.implementsPOLP is False</dd>
+  <dd>target.controls.validatesInput is False or target.controls.implementsPOLP is False</dd>
 </dl>
 
 
@@ -2282,7 +2282,7 @@ An adversary corrupts or modifies the content of a schema for the purpose of und
   <dd>https://capec.mitre.org/data/definitions/271.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.implementsPOLP is False</dd>
+  <dd>target.controls.implementsPOLP is False</dd>
 </dl>
 
 
@@ -2308,7 +2308,7 @@ An attacker injects content into a server response that is interpreted different
   <dd>https://capec.mitre.org/data/definitions/273.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.implementsStrictHTTPValidation is False and target.encodesHeaders is False</dd>
+  <dd>target.controls.implementsStrictHTTPValidation is False and target.controls.encodesHeaders is False</dd>
 </dl>
 
 
@@ -2334,7 +2334,7 @@ HTTP Request Smuggling results from the discrepancies in parsing HTTP requests b
   <dd>https://capec.mitre.org/data/definitions/33.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.implementsStrictHTTPValidation is False and target.encodesHeaders is False</dd>
+  <dd>target.controls.implementsStrictHTTPValidation is False and target.controls.encodesHeaders is False</dd>
 </dl>
 
 
@@ -2360,7 +2360,7 @@ This type of attack is a form of Cross-Site Scripting (XSS) where a malicious sc
   <dd>https://capec.mitre.org/data/definitions/588.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.allowsClientSideScripting is True and (target.sanitizesInput is False or target.validatesInput is False)</dd>
+  <dd>target.allowsClientSideScripting is True and (target.controls.sanitizesInput is False or target.controls.validatesInput is False)</dd>
 </dl>
 
 
@@ -2386,7 +2386,7 @@ This attack targets predictable session ID in order to gain privileges. The atta
   <dd>https://capec.mitre.org/data/definitions/59.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.usesStrongSessionIdentifiers is False</dd>
+  <dd>target.controls.usesStrongSessionIdentifiers is False</dd>
 </dl>
 
 
@@ -2412,7 +2412,7 @@ This type of attack is a form of Cross-Site Scripting (XSS) where a malicious sc
   <dd>https://capec.mitre.org/data/definitions/591.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.allowsClientSideScripting is True and (target.sanitizesInput is False or target.validatesInput is False)</dd>
+  <dd>target.allowsClientSideScripting is True and (target.controls.sanitizesInput is False or target.controls.validatesInput is False)</dd>
 </dl>
 
 
@@ -2438,7 +2438,7 @@ This type of attack is a form of Cross-site Scripting (XSS) where a malicious sc
   <dd>https://capec.mitre.org/data/definitions/592.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.allowsClientSideScripting is True and (target.sanitizesInput is False or target.validatesInput is False)</dd>
+  <dd>target.allowsClientSideScripting is True and (target.controls.sanitizesInput is False or target.controls.validatesInput is False)</dd>
 </dl>
 
 
@@ -2464,7 +2464,7 @@ This type of attack involves an adversary that exploits weaknesses in an applica
   <dd>https://capec.mitre.org/data/definitions/593.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.usesStrongSessionIdentifiers is False</dd>
+  <dd>target.controls.usesStrongSessionIdentifiers is False</dd>
 </dl>
 
 
@@ -2490,7 +2490,7 @@ This type of attack involves an adversary that exploits weaknesses in an applica
   <dd>https://capec.mitre.org/data/definitions/593.html</dd>
 
   <dt>Condition</dt>
-  <dd>(target.usesStrongSessionIdentifiers is False or target.encryptsCookies is False) and target.definesConnectionTimeout is False</dd>
+  <dd>(target.controls.usesStrongSessionIdentifiers is False or target.controls.encryptsCookies is False) and target.controls.definesConnectionTimeout is False</dd>
 </dl>
 
 
@@ -2516,7 +2516,7 @@ An attacker changes the behavior or state of a targeted application through inje
   <dd>https://capec.mitre.org/data/definitions/6.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.validatesInput is False or target.sanitizesInput is False</dd>
+  <dd>target.controls.validatesInput is False or target.controls.sanitizesInput is False</dd>
 </dl>
 
 
@@ -2542,7 +2542,7 @@ This attack targets the reuse of valid session ID to spoof the target system in 
   <dd>https://capec.mitre.org/data/definitions/60.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.usesSessionTokens is True and target.implementsNonce is False</dd>
+  <dd>target.usesSessionTokens is True and target.controls.implementsNonce is False</dd>
 </dl>
 
 
@@ -2568,7 +2568,7 @@ This attack targets the reuse of valid session ID to spoof the target system in 
   <dd>https://capec.mitre.org/data/definitions/60.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.definesConnectionTimeout is False and (target.usesMFA is False or target.encryptsSessionData is False)</dd>
+  <dd>target.controls.definesConnectionTimeout is False and (target.controls.usesMFA is False or target.controls.encryptsSessionData is False)</dd>
 </dl>
 
 
@@ -2594,7 +2594,7 @@ An attacker crafts malicious web links and distributes them (via web pages, emai
   <dd>https://capec.mitre.org/data/definitions/62.html</dd>
 
   <dt>Condition</dt>
-  <dd>target.implementsCSRFToken is False or target.verifySessionIdentifiers is False</dd>
+  <dd>target.controls.implementsCSRFToken is False or target.controls.verifySessionIdentifiers is False</dd>
 </dl>
 
 
@@ -2646,7 +2646,7 @@ An attacker can access data in transit or at rest that is not sufficiently prote
   <dd>https://cwe.mitre.org/data/definitions/311.html, https://cwe.mitre.org/data/definitions/312.html, https://cwe.mitre.org/data/definitions/916.html, https://cwe.mitre.org/data/definitions/653.html</dd>
 
   <dt>Condition</dt>
-  <dd>(target.hasDataLeaks() or any(d.isCredentials or d.isPII for d in target.data)) and (not target.isEncrypted or (not target.isResponse and any(d.isStored and d.isDestEncryptedAtRest for d in target.data)) or (target.isResponse and any(d.isStored and d.isSourceEncryptedAtRest for d in target.data)))</dd>
+  <dd>(target.hasDataLeaks() or any(d.isCredentials or d.isPII for d in target.data)) and (not target.controls.isEncrypted or (not target.isResponse and any(d.isStored and d.isDestEncryptedAtRest for d in target.data)) or (target.isResponse and any(d.isStored and d.isSourceEncryptedAtRest for d in target.data)))</dd>
 </dl>
 
 

--- a/pytm/__init__.py
+++ b/pytm/__init__.py
@@ -1,6 +1,7 @@
 __all__ = [
     "Action",
     "Actor",
+    "Assumption",
     "Boundary",
     "Classification",
     "TLSVersion",
@@ -29,6 +30,7 @@ from .pytm import (
     TM,
     Action,
     Actor,
+    Assumption,
     Boundary,
     Classification,
     Data,

--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -218,8 +218,7 @@ class varData(var):
                 )
             ]
             sys.stderr.write(
-                "FIXME: a dataflow is using a string as the Data attribute. "
-                "This has been deprecated and Data objects should be created instead.\n"
+                "FIXME: a dataflow is using a string as the Data attribute. This has been deprecated and Data objects should be created instead.\n"
             )
 
         if not isinstance(value, Iterable):
@@ -227,7 +226,9 @@ class varData(var):
         for i, e in enumerate(value):
             if not isinstance(e, Data):
                 raise ValueError(
-                    f"expecting a list of pytm.Data, item number {i} is a {type(e)}"
+                    "expecting a list of pytm.Data, item number {} is a {}".format(
+                        i, type(e)
+                    )
                 )
         super().__set__(instance, DataSet(value))
 
@@ -852,7 +853,7 @@ with same properties, except name and notes""",
         findings = []
         excluded_findings = []
         elements = defaultdict(list)
-        for e in TM._elements:  # type: Element
+        for e in TM._elements:
             if not e.inScope:
                 continue
 
@@ -866,7 +867,7 @@ with same properties, except name and notes""",
             except AttributeError:
                 pass
 
-            for t in TM._threats:  # type: Threat
+            for t in TM._threats:
                 if not t.apply(e) and t.id not in override_ids:
                     continue
 
@@ -1374,7 +1375,7 @@ and only the user has), and inherence (something the user and only the user is).
 
 class Assumption:
     """
-    Assumption implemented by/on an Element.
+    Assumption used by an Element.
     Used to exclude threats on a per-element basis.
     """
     name = varString("", required=True)

--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -218,7 +218,8 @@ class varData(var):
                 )
             ]
             sys.stderr.write(
-                "FIXME: a dataflow is using a string as the Data attribute. This has been deprecated and Data objects should be created instead.\n"
+                "FIXME: a dataflow is using a string as the Data attribute. "
+                "This has been deprecated and Data objects should be created instead.\n"
             )
 
         if not isinstance(value, Iterable):
@@ -226,9 +227,7 @@ class varData(var):
         for i, e in enumerate(value):
             if not isinstance(e, Data):
                 raise ValueError(
-                    "expecting a list of pytm.Data, item number {} is a {}".format(
-                        i, type(e)
-                    )
+                    f"expecting a list of pytm.Data, item number {i} is a {type(e)}"
                 )
         super().__set__(instance, DataSet(value))
 
@@ -263,7 +262,26 @@ class varControls(var):
     def __set__(self, instance, value):
         if not isinstance(value, Controls):
             raise ValueError(
-                "expecting an Controls " "value, got a {}".format(type(value))
+                f"expecting an Controls value, got a {type(value)}"
+            )
+        super().__set__(instance, value)
+
+
+class varAssumptions(var):
+    def __set__(self, instance, value):
+        for i, e in enumerate(value):
+            if not isinstance(e, Assumption):
+                raise ValueError(
+                    f"expecting a list of Assumptions, item number {i} is a {type(e)}"
+                )
+        super().__set__(instance, list(value))
+
+
+class varAssumption(var):
+    def __set__(self, instance, value):
+        if not isinstance(value, Assumption):
+            raise ValueError(
+                f"expecting an Assumption value, got a {type(value)}"
             )
         super().__set__(instance, value)
 
@@ -666,12 +684,13 @@ class Finding:
     threat_id = varString("", required=True, doc="Threat ID")
     references = varString("", required=True, doc="Threat references")
     condition = varString("", required=True, doc="Threat condition")
+    assumption = varAssumption(None, required=False, doc="The assumption, that caused this finding to be excluded")
     response = varString(
         "",
         required=False,
         doc="""Describes how this threat matching this particular asset or dataflow is being handled.
 Can be one of:
-* mitigated - there were changes made in the modeled system to reduce the probability of this threat ocurring or the impact when it does,
+* mitigated - there were changes made in the modeled system to reduce the probability of this threat occurring or the impact when it does,
 * transferred - users of the system are required to mitigate this threat,
 * avoided - this asset or dataflow is removed from the system,
 * accepted - no action is taken as the probability and/or impact is very low
@@ -773,7 +792,12 @@ class TM:
     isOrdered = varBool(False, doc="Automatically order all Dataflows")
     mergeResponses = varBool(False, doc="Merge response edges in DFDs")
     ignoreUnused = varBool(False, doc="Ignore elements not used in any Dataflow")
-    findings = varFindings([], doc="threats found for elements of this model")
+    findings = varFindings([], doc="Threats found for elements of this model")
+    excluded_findings = varFindings(
+        [],
+        doc="Threats found for elements of this model, "
+        "that were excluded on a per-element basis, using the Assumptions class"
+    )
     onDuplicates = varAction(
         Action.NO_ACTION,
         doc="""How to handle duplicate Dataflow
@@ -824,9 +848,11 @@ with same properties, except name and notes""",
 
     def resolve(self):
         finding_count = 0
+        excluded_finding_count = 0
         findings = []
+        excluded_findings = []
         elements = defaultdict(list)
-        for e in TM._elements:
+        for e in TM._elements:  # type: Element
             if not e.inScope:
                 continue
 
@@ -840,11 +866,22 @@ with same properties, except name and notes""",
             except AttributeError:
                 pass
 
-            for t in TM._threats:
+            for t in TM._threats:  # type: Threat
                 if not t.apply(e) and t.id not in override_ids:
                     continue
 
                 if t.id in TM._threatsExcluded:
+                    continue
+
+                _continue = False
+                for assumption in e.assumptions:  # type: Assumption
+                    if t.id in assumption.exclude:
+                        excluded_finding_count += 1
+                        f = Finding(e, id=str(excluded_finding_count), threat=t, assumption=assumption)
+                        excluded_findings.append(f)
+                        _continue = True
+                        break
+                if _continue:
                     continue
 
                 finding_count += 1
@@ -853,6 +890,7 @@ with same properties, except name and notes""",
                 elements[e].append(f)
                 e._set_severity(f.severity)
         self.findings = findings
+        self.excluded_findings = excluded_findings
         for e, findings in elements.items():
             e.findings = findings
 
@@ -1334,6 +1372,21 @@ and only the user has), and inherence (something the user and only the user is).
             pass
 
 
+class Assumption:
+    """
+    Assumption implemented by/on an Element.
+    Used to exclude threats on a per-element basis.
+    """
+    name = varString("", required=True)
+    exclude = varStrings([], doc="A list of threat SIDs to exclude for this assumption. For example: INP01")
+    description = varString("", doc="An additional description of the assumption")
+
+    def __init__(self, name, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        self.name = name
+
+
 class Element:
     """A generic element"""
 
@@ -1356,6 +1409,10 @@ class Element:
         [],
         doc="""Overrides to findings, allowing to set
 a custom response, CVSS score or override other attributes.""",
+    )
+    assumptions = varAssumptions(
+        [],
+        doc="Assumptions about the element. These optionally allow to exclude threats with the given SIDs.",
     )
     levels = varInts({0}, doc="List of levels (0, 1, 2, ...) to be drawn in the model.")
     sourceFiles = varStrings(

--- a/tests/output.json
+++ b/tests/output.json
@@ -2,6 +2,7 @@
     "actors": [
         {
             "__class__": "Actor",
+            "assumptions": [],
             "controls": {
                 "authenticatesDestination": false,
                 "authenticatesSource": false,
@@ -76,6 +77,7 @@
         {
             "OS": "",
             "__class__": "Server",
+            "assumptions": [],
             "controls": {
                 "authenticatesDestination": false,
                 "authenticatesSource": false,
@@ -157,6 +159,7 @@
         {
             "OS": "",
             "__class__": "Lambda",
+            "assumptions": [],
             "controls": {
                 "authenticatesDestination": false,
                 "authenticatesSource": false,
@@ -232,6 +235,7 @@
             "OS": "",
             "__class__": "Process",
             "allowsClientSideScripting": false,
+            "assumptions": [],
             "codeType": "Unmanaged",
             "controls": {
                 "authenticatesDestination": false,
@@ -309,6 +313,7 @@
         {
             "OS": "",
             "__class__": "Datastore",
+            "assumptions": [],
             "controls": {
                 "authenticatesDestination": false,
                 "authenticatesSource": false,
@@ -393,6 +398,7 @@
     "assumptions": [],
     "boundaries": [
         {
+            "assumptions": [],
             "controls": {
                 "authenticatesDestination": false,
                 "authenticatesSource": false,
@@ -453,6 +459,7 @@
             "sourceFiles": []
         },
         {
+            "assumptions": [],
             "controls": {
                 "authenticatesDestination": false,
                 "authenticatesSource": false,
@@ -539,6 +546,7 @@
     "elements": [
         {
             "__class__": "Actor",
+            "assumptions": [],
             "controls": {
                 "authenticatesDestination": false,
                 "authenticatesSource": false,
@@ -611,6 +619,7 @@
         {
             "OS": "",
             "__class__": "Server",
+            "assumptions": [],
             "controls": {
                 "authenticatesDestination": false,
                 "authenticatesSource": false,
@@ -692,6 +701,7 @@
         {
             "OS": "",
             "__class__": "Lambda",
+            "assumptions": [],
             "controls": {
                 "authenticatesDestination": false,
                 "authenticatesSource": false,
@@ -767,6 +777,7 @@
             "OS": "",
             "__class__": "Process",
             "allowsClientSideScripting": false,
+            "assumptions": [],
             "codeType": "Unmanaged",
             "controls": {
                 "authenticatesDestination": false,
@@ -844,6 +855,7 @@
         {
             "OS": "",
             "__class__": "Datastore",
+            "assumptions": [],
             "controls": {
                 "authenticatesDestination": false,
                 "authenticatesSource": false,
@@ -925,9 +937,11 @@
             "usesEnvironmentVariables": false
         }
     ],
+    "excluded_findings": [],
     "findings": [],
     "flows": [
         {
+            "assumptions": [],
             "controls": {
                 "authenticatesDestination": false,
                 "authenticatesSource": false,
@@ -1005,6 +1019,7 @@
             "usesVPN": false
         },
         {
+            "assumptions": [],
             "controls": {
                 "authenticatesDestination": false,
                 "authenticatesSource": false,
@@ -1080,6 +1095,7 @@
             "usesVPN": false
         },
         {
+            "assumptions": [],
             "controls": {
                 "authenticatesDestination": false,
                 "authenticatesSource": false,
@@ -1155,6 +1171,7 @@
             "usesVPN": false
         },
         {
+            "assumptions": [],
             "controls": {
                 "authenticatesDestination": false,
                 "authenticatesSource": false,
@@ -1230,6 +1247,7 @@
             "usesVPN": false
         },
         {
+            "assumptions": [],
             "controls": {
                 "authenticatesDestination": false,
                 "authenticatesSource": false,
@@ -1305,6 +1323,7 @@
             "usesVPN": false
         },
         {
+            "assumptions": [],
             "controls": {
                 "authenticatesDestination": false,
                 "authenticatesSource": false,

--- a/tests/test_pytmfunc.py
+++ b/tests/test_pytmfunc.py
@@ -11,6 +11,7 @@ from pytm import (
     TM,
     Action,
     Actor,
+    Assumption,
     Boundary,
     Classification,
     Data,
@@ -496,6 +497,36 @@ class TestTM(unittest.TestCase):
             x.write(output)
         self.maxDiff = None
         self.assertEqual(output, level_1)
+
+    def test_element_assumptions(self):
+        web = Server("Web Server")
+        assumption1 = Assumption("Assumption 1", exclude=["INP01", "INP02"])
+        assumption2 = Assumption("Assumption 2", exclude=["INP03"])
+        web.assumptions = [assumption1, assumption2]
+
+        self.assertEqual(len(web.assumptions), 2)
+        self.assertEqual(web.assumptions[0].name, "Assumption 1")
+        self.assertSetEqual(web.assumptions[0].exclude, {"INP01", "INP02"})
+        self.assertEqual(web.assumptions[1].name, "Assumption 2")
+        self.assertSetEqual(web.assumptions[1].exclude, {"INP03"})
+
+        # Test adding an invalid assumption
+        with self.assertRaises(ValueError):
+            web.assumptions = [assumption1, "Invalid Assumption"]
+
+    def test_exclude_threats_by_assumptions(self):
+        # Test excluding threats based on assumptions
+        web = Server("Web Server")
+        assumption = Assumption("Assumption", exclude=["INP03"])
+        web.assumptions = [assumption]
+        web.controls.sanitizesInput = False
+        web.controls.encodesOutput = False
+
+        tm = TM("Test TM")
+        tm.resolve()
+
+        self.assertNotIn("INP03", [f.threat_id for f in web.findings])
+        self.assertIn("INP03", [f.threat_id for f in tm.excluded_findings])
 
 
 class Testpytm(unittest.TestCase):

--- a/tm.py
+++ b/tm.py
@@ -11,14 +11,17 @@ from pytm import (
     Lambda,
     Server,
     DatastoreType,
+    Assumption,
 )
 
 tm = TM("my test tm")
-tm.description = "This is a sample threat model of a very simple system - a web-based comment system. The user enters comments and these are added to a database and displayed back to the user. The thought is that it is, though simple, a complete enough example to express meaningful threats."
+tm.description = """This is a sample threat model of a very simple system - a web-based comment system. 
+The user enters comments and these are added to a database and displayed back to the user. 
+The thought is that it is, though simple, a complete enough example to express meaningful threats."""
 tm.isOrdered = True
 tm.mergeResponses = True
 tm.assumptions = [
-"Here you can document a list of assumptions about the system",
+    "Here you can document a list of assumptions about the system",
 ]
 
 internet = Boundary("Internet")
@@ -39,6 +42,12 @@ web.controls.sanitizesInput = False
 web.controls.encodesOutput = True
 web.controls.authorizesSource = False
 web.sourceFiles = ["pytm/json.py", "docs/template.md"]
+web.assumptions = [
+    Assumption(
+        "This webserver does not use PHP",
+        exclude=["INP16"],
+    ),
+]
 
 db = Datastore("SQL Database")
 db.OS = "CentOS"


### PR DESCRIPTION
Fixes #244
This adds an Assumption class to Elements, as described in the Issue #244 by @raphaelahrens 

It allows someone to set a list of assumptions for elements, which also allow (optionally) to exclude a list of SIDs. 

All Findings, that match one of the SIDs, will not be included in the findings list. Instead there is a new list `excluded_findings` on the TM class. This allows the excluded threats to be shown in a separate section in the report. 

To demonstrate this, I also added this feature to the reference `tm.py` threat model and added a new section to the advanced template. 

I am not sure about the html files in the docs folder. I noticed there are make commands to update them, but they weren't updated in along while so I wasn't sure, whether to include them. But just let me know, if that was wrong and I will remove them from the Pull request.