### PR TITLE
Refactor of the `serialize` and `to_serializable` function

### DIFF
--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -1496,7 +1496,7 @@ a custom response, CVSS score or override other attributes.""",
         return self.name
 
     def _label(self):
-        return "\\n".join(wrap(self.display_name(), 18))
+        return "\\n".join(wrap(html.escape(self.display_name()), 18))
 
     def _shape(self):
         return "square"


### PR DESCRIPTION
This commit tries to tackle #268 and rewrite the `serialize` function to handle less class specific cases and move it into the single dispatch function `to_serializable`.