### PR TITLE
add ruff gh workflow

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,48 @@
+name: ruff
+
+on:
+  push:
+  # temporary disabled during development
+  #  branches:
+  #    - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  # write permissions required to apply safe fixes
+  contents: write
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: |
+            pytm
+            pyproject.toml
+            .github/workflows/ruff.yml
+      # https://github.com/astral-sh/ruff-action
+      # https://docs.astral.sh/ruff/formatter/
+      - name: Format production code
+        uses: astral-sh/ruff-action@v3
+        with:
+          src: pytm
+          version: "latest"
+          args: "format --check"
+      # https://docs.astral.sh/ruff/linter/
+      - name: Fix production code (safe fixes only)
+        uses: astral-sh/ruff-action@v3
+        with:
+          src: pytm
+          version: "latest"
+          args: "check --fix"
+      - name: Show unsafe production code fixes
+        uses: astral-sh/ruff-action@v3
+        with:
+          src: pytm
+          version: "latest"
+          args: "check --fix --unsafe-fixes"

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           src: pytm
           version: "latest"
-          args: "format --check"
+          args: "format"
       # https://docs.astral.sh/ruff/linter/
       - name: Fix production code (safe fixes only)
         uses: astral-sh/ruff-action@v3

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -2,16 +2,14 @@ name: ruff
 
 on:
   push:
-  # temporary disabled during development
-  #  branches:
-  #    - master
+    branches:
+      - master
   pull_request:
     branches:
       - master
 
 permissions:
-  # write permissions required to apply safe fixes
-  contents: write
+  contents: read
 
 jobs:
   ruff:
@@ -27,22 +25,30 @@ jobs:
             .github/workflows/ruff.yml
       # https://github.com/astral-sh/ruff-action
       # https://docs.astral.sh/ruff/formatter/
-      - name: Format production code
+      - name: Check production code format
         uses: astral-sh/ruff-action@v3
         with:
           src: pytm
           version: "latest"
-          args: "format"
+          args: "format --check"
+      - name: Check production code
+        uses: astral-sh/ruff-action@v3
+        with:
+          src: pytm
+          version: "latest"
+          args: "check --output-format=github"
       # https://docs.astral.sh/ruff/linter/
-      - name: Fix production code (safe fixes only)
+      - name: Show helpful safe production code fixes
         uses: astral-sh/ruff-action@v3
         with:
           src: pytm
           version: "latest"
-          args: "check --fix"
-      - name: Show unsafe production code fixes
+          args: "check --fix --diff --output-format=github"
+        continue-on-error: true
+      - name: Show potentially helpful unsafe production code fixes
         uses: astral-sh/ruff-action@v3
         with:
           src: pytm
           version: "latest"
-          args: "check --fix --unsafe-fixes"
+          args: "check --fix --diff --unsafe-fixes --output-format=github"
+        continue-on-error: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ external = []
 fixable = ["ALL"]
 future-annotations = false
 ignore = []
-ignore-init-module-imports = true
 logger-objects = []
 per-file-ignores = {}
 preview = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,52 @@ pdoc3 = "^0.11.6"
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
+
+[tool.ruff]
+target-version = "py310"
+
+# https://docs.astral.sh/ruff/settings/#analyze
+[tool.ruff.analyze]
+detect-string-imports = false
+direction = "dependencies"
+exclude = []
+include-dependencies = {}
+preview = false
+string-imports-min-dots = 2
+
+# https://docs.astral.sh/ruff/settings/#format
+[tool.ruff.format]
+docstring-code-format = true
+docstring-code-line-length = "dynamic"
+exclude = []
+indent-style = "space"
+line-ending = "lf"
+preview = false
+quote-style = "double"
+skip-magic-trailing-comma = false
+
+# https://docs.astral.sh/ruff/settings/#lint
+[tool.ruff.lint]
+allowed-confusables = []
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+exclude = []
+explicit-preview-rules = false
+extend-fixable = []
+extend-ignore = []
+extend-per-file-ignores = {}
+extend-safe-fixes = []
+extend-select = []
+extend-unsafe-fixes = []
+external = []
+fixable = ["ALL"]
+future-annotations = false
+ignore = []
+ignore-init-module-imports = true
+logger-objects = []
+per-file-ignores = {}
+preview = false
+select = ["E4", "E7", "E9", "F"]
+task-tags = ["TODO", "FIXME", "XXX"]
+typing-extensions = true
+typing-modules = []
+unfixable = []


### PR DESCRIPTION
- Closes #292 
- Extends #290 
- Action output will look similar [to this action output](https://github.com/fkromer/pytm/actions/runs/18922580892/job/54022234669) ("Check production code format" as well as "Check production code" will fail instead of pass like [here](https://github.com/OWASP/pytm/actions/runs/18922745884/job/54022800661?pr=299))