### PR TITLE
Upgrade Docker base image to python:alpine3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM python:3.12-rc-alpine
+FROM python:alpine3.20
 
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
Updates the Docker base image from python:3.12-rc-alpine to python:alpine3.20 as suggested in issue #251 to reduce open-source vulnerabilities.