### PR TITLE
Add JSON template and examples to simplify threat model creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,24 @@ Element class attributes:
   onAWS                           default: False
 
 ```
-## Quick Threat Model Creation Using JSON Template
+
+
+## Using the JSON Template
 
 To simplify initial threat model creation, pytm provides a JSON template.
 
-Users can copy `examples/template_tm.json` and modify it to define their threat model.
-This reduces the amount of manual typing required when creating a new threat model.
+1. Copy the file `examples/template_tm.json`.
+2. Modify the elements and flows according to your system.
+3. Load the JSON file in pytm using the built-in JSON import feature.
+
+Example:
+
+python
+from pytm import TM
+
+tm = TM("Example Threat Model")
+tm.load("template_tm.json")
+
 
 
 The *colormap* argument, used together with *dfd*, outputs a color-coded DFD where the elements are painted red, yellow or green depending on their risk level (as identified by running the rules).

--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ Element class attributes:
   onAWS                           default: False
 
 ```
+## Quick Threat Model Creation Using JSON Template
+
+To simplify initial threat model creation, pytm provides a JSON template.
+
+Users can copy `examples/template_tm.json` and modify it to define their threat model.
+This reduces the amount of manual typing required when creating a new threat model.
+
 
 The *colormap* argument, used together with *dfd*, outputs a color-coded DFD where the elements are painted red, yellow or green depending on their risk level (as identified by running the rules).
 

--- a/examples/template_tm.json
+++ b/examples/template_tm.json
@@ -1,31 +1,64 @@
 {
   "name": "my test tm",
   "description": "Sample threat model of a simple web-based comment system.",
+  "boundaries": [
+    { "name": "Internet" },
+    { "name": "Server/DB", "levels": [2] },
+    { "name": "AWS VPC" }
+  ],
   "elements": [
     {
       "name": "User",
       "type": "Actor",
-      "boundary": "Internet"
+      "boundary": "Internet",
+      "levels": [2]
     },
     {
       "name": "Web Server",
       "type": "Server",
       "os": "Ubuntu",
-      "boundary": "Server/DB"
+      "boundary": "Server/DB",
+      "controls": {
+        "isHardened": true,
+        "sanitizesInput": false,
+        "encodesOutput": true,
+        "authorizesSource": false
+      }
     },
     {
       "name": "SQL Database",
       "type": "Datastore",
       "os": "CentOS",
-      "boundary": "Server/DB"
-    }
-  ],
-  "boundaries": [
-    {
-      "name": "Internet"
+      "boundary": "Server/DB",
+      "datastoreType": "SQL",
+      "inScope": true
     },
     {
-      "name": "Server/DB"
+      "name": "Real Identity Database",
+      "type": "Datastore",
+      "os": "CentOS",
+      "boundary": "Server/DB",
+      "datastoreType": "SQL",
+      "storesPII": true
+    },
+    {
+      "name": "AWS Lambda",
+      "type": "Lambda",
+      "boundary": "AWS VPC"
+    }
+  ],
+  "data": [
+    {
+      "name": "Comments in HTML or Markdown",
+      "classification": "PUBLIC"
+    },
+    {
+      "name": "Insert query with comments",
+      "classification": "PUBLIC"
+    },
+    {
+      "name": "Token verifying user identity",
+      "classification": "SECRET"
     }
   ],
   "flows": [
@@ -34,14 +67,16 @@
       "target": "Web Server",
       "description": "User enters comments",
       "protocol": "HTTP",
-      "port": 80
+      "port": 80,
+      "data": "Comments in HTML or Markdown"
     },
     {
       "source": "Web Server",
       "target": "SQL Database",
       "description": "Insert query with comments",
       "protocol": "MySQL",
-      "port": 3306
+      "port": 3306,
+      "data": "Insert query with comments"
     },
     {
       "source": "SQL Database",
@@ -56,6 +91,21 @@
       "description": "Show comments",
       "protocol": "HTTP",
       "port": 80
+    },
+    {
+      "source": "AWS Lambda",
+      "target": "SQL Database",
+      "description": "Serverless function cleans DB",
+      "protocol": "MySQL",
+      "port": 3306
+    },
+    {
+      "source": "SQL Database",
+      "target": "Real Identity Database",
+      "description": "Verify real user identity",
+      "protocol": "RDA-TCP",
+      "port": 40234,
+      "data": "Token verifying user identity"
     }
   ]
 }

--- a/examples/template_tm.json
+++ b/examples/template_tm.json
@@ -1,0 +1,20 @@
+{
+  "name": "Sample Threat Model",
+  "elements": [
+    {
+      "name": "User",
+      "type": "Actor"
+    },
+    {
+      "name": "WebServer",
+      "type": "Server"
+    }
+  ],
+  "flows": [
+    {
+      "source": "User",
+      "target": "WebServer"
+    }
+  ]
+}
+

--- a/examples/template_tm.json
+++ b/examples/template_tm.json
@@ -1,20 +1,61 @@
 {
-  "name": "Sample Threat Model",
+  "name": "my test tm",
+  "description": "Sample threat model of a simple web-based comment system.",
   "elements": [
     {
       "name": "User",
-      "type": "Actor"
+      "type": "Actor",
+      "boundary": "Internet"
     },
     {
-      "name": "WebServer",
-      "type": "Server"
+      "name": "Web Server",
+      "type": "Server",
+      "os": "Ubuntu",
+      "boundary": "Server/DB"
+    },
+    {
+      "name": "SQL Database",
+      "type": "Datastore",
+      "os": "CentOS",
+      "boundary": "Server/DB"
+    }
+  ],
+  "boundaries": [
+    {
+      "name": "Internet"
+    },
+    {
+      "name": "Server/DB"
     }
   ],
   "flows": [
     {
       "source": "User",
-      "target": "WebServer"
+      "target": "Web Server",
+      "description": "User enters comments",
+      "protocol": "HTTP",
+      "port": 80
+    },
+    {
+      "source": "Web Server",
+      "target": "SQL Database",
+      "description": "Insert query with comments",
+      "protocol": "MySQL",
+      "port": 3306
+    },
+    {
+      "source": "SQL Database",
+      "target": "Web Server",
+      "description": "Retrieve comments",
+      "protocol": "MySQL",
+      "port": 3306
+    },
+    {
+      "source": "Web Server",
+      "target": "User",
+      "description": "Show comments",
+      "protocol": "HTTP",
+      "port": 80
     }
   ]
 }
-


### PR DESCRIPTION
### Summary
This PR adds a JSON template and an examples folder to simplify the initial creation of threat models in pytm.

### Motivation
Issue #12 mentions that creating a threat model requires a lot of manual typing.  
Providing a ready-to-use JSON template helps users quickly bootstrap their threat models with minimal effort.

### Changes
- Added `examples/template_tm.json` as a starter template for threat models.
- Updated README with instructions for using the JSON template.

### Related Issue
Addresses #12
