### PR TITLE
Add likelihood field to Finding

### DIFF
--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -700,6 +700,7 @@ Can be one of:
 """,
     )
     cvss = varString("", required=False, doc="The CVSS score and/or vector")
+    likelihood = varString("", required=False, doc="Likelihood of the threat")
 
     def __init__(
         self,
@@ -721,6 +722,7 @@ Can be one of:
             "example",
             "references",
             "condition",
+            "likelihood",
         ]
         threat = kwargs.pop("threat", None)
         if threat:
@@ -2141,6 +2143,7 @@ def encode_threat_data(obj):
         "condition",
         "cvss",
         "response",
+        "likelihood",
     ]
 
     if type(obj) is Finding or (len(obj) != 0 and type(obj[0]) is Finding):


### PR DESCRIPTION
## Summary
- Adds the `likelihood` string field to the `Finding` class, alongside the existing `cvss` field
- Includes `likelihood` in the serializable fields list in `encode_threat_data`

## How to test
Run the new pytm version with a sample threat model and verified `likelihood` is part of the output:
```
> jq '.findings[0]' /tmp/out.json
{
  "assumption": null,
  "condition": "target.controls.handlesResourceConsumption is False or target.controls.isResilient is False",
  "cvss": "",
  "description": "Flooding",
  "details": "...",
  "example": "Adversary tries to bring a network or service down by flooding it with large amounts of traffic.",
  "id": "1",
  **"likelihood": "High"**,
  "mitigations": "...",
  "response": "",
  "severity": "Medium",
  "target": "React Frontend",
  "threat_id": "DO01"
}
```

## How to validate
- [ ] Verify `likelihood` can be set on a `Finding` object
- [ ] Verify `likelihood` appears in JSON/report output