### PR TITLE
Update makefile/dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,28 @@
+FROM python:3.14.4-alpine3.23
 
-FROM python:alpine3.20
+WORKDIR /app
+ENTRYPOINT ["/app/entrypoint.sh"]
 
-
-WORKDIR /usr/src/app
-ENTRYPOINT ["sh"]
-
-ENV PLANTUML_VER 1.2021.7
-ENV PLANTUML_PATH /usr/local/lib/plantuml.jar
-ENV PANDOC_VER 2.14.0.1
+ENV PLANTUML_VER=1.2026.2
+ENV PLANTUML_PATH=/usr/local/lib/plantuml.jar
+ENV PANDOC_VER=2.19.2
 
 RUN apk add --no-cache graphviz openjdk11-jre fontconfig make curl ttf-liberation ttf-linux-libertine ttf-dejavu \
     && apk add --no-cache --virtual .build-deps gcc musl-dev \
     && rm -rf /var/cache/apk/* \
-    && curl -LO https://master.dl.sourceforge.net/project/plantuml/$PLANTUML_VER/plantuml.$PLANTUML_VER.jar \
-    && mv plantuml.$PLANTUML_VER.jar $PLANTUML_PATH \
+    && curl -LO https://github.com/plantuml/plantuml/releases/download/v$PLANTUML_VER/plantuml-mit-$PLANTUML_VER.jar \
+    && mv plantuml-mit-$PLANTUML_VER.jar $PLANTUML_PATH \
     && curl -LO https://github.com/jgm/pandoc/releases/download/$PANDOC_VER/pandoc-$PANDOC_VER-linux-amd64.tar.gz \
     && tar xvzf pandoc-$PANDOC_VER-linux-amd64.tar.gz --strip-components 1 -C /usr/local/
 
-ENV _JAVA_OPTIONS -Duser.home=/tmp -Dawt.useSystemAAFontSettings=gasp
+ENV _JAVA_OPTIONS=-Duser.home=/tmp -Dawt.useSystemAAFontSettings=gasp
 RUN printf '@startuml\n@enduml' | java -Djava.awt.headless=true -jar $PLANTUML_PATH -tpng -pipe >/dev/null
 
-COPY requirements.txt requirements-dev.txt ./
-RUN pip install --no-cache-dir -r requirements-dev.txt \
-    && apk del .build-deps
-
+COPY pyproject.toml ./
 COPY pytm ./pytm
 COPY docs ./docs
-COPY *.py Makefile ./
+COPY *.py Makefile entrypoint.sh ./
+
+RUN pip install poetry \
+    && poetry config virtualenvs.create false \
+    && poetry install

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,5 @@
-MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
-CWD := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 DOCKER_IMG := pytm
 
-ifeq ($(USE_DOCKER),true)
-	SHELL=docker
-	.SHELLFLAGS=run -u $$(id -u) -v $(CWD):/usr/src/app --rm $(DOCKER_IMG):latest -c
-endif
 ifndef PLANTUML_PATH
 	export PLANTUML_PATH = ./plantuml.jar
 endif
@@ -24,7 +18,7 @@ endif
 
 
 docs/pytm/index.html: $(wildcard pytm/*.py)
-	PYTHONPATH=. pdoc --html --force --output-dir docs pytm
+	poetry run pdoc --html --force --output-dir docs pytm
 
 docs/threats.md: $(wildcard pytm/threatlib/*.json)
 	printf "# Threat database\n" > $@
@@ -38,13 +32,13 @@ $(MODEL): safe_filename
 	$(MAKE) MODEL=$(MODEL) report
 
 $(MODEL)/dfd.png: $(MODEL).py $(libs)
-	./$< --dfd | dot -Tpng -o $@
+	poetry run python $< --dfd | dot -Tpng -o $@
 
 $(MODEL)/seq.png: $(MODEL).py $(libs)
-	./$< --seq | java -Djava.awt.headless=true -jar $$PLANTUML_PATH -tpng -pipe > $@
+	poetry run python $< --seq | java -Djava.awt.headless=true -jar $$PLANTUML_PATH -tpng -pipe > $@
 
 $(MODEL)/report.html: $(MODEL).py $(libs) docs/basic_template.md docs/Stylesheet.css
-	./$< --report docs/basic_template.md | pandoc -f markdown -t html > $@
+	poetry run python $< --report docs/basic_template.md | pandoc -f markdown-tex_math_dollars -t html > $@
 
 dfd: $(MODEL)/dfd.png
 
@@ -54,11 +48,11 @@ report: $(MODEL)/report.html seq dfd
 
 .PHONY: test
 test:
-	@python3 -m unittest
+	poetry run pytest
 
 .PHONY: describe
 describe:
-	./tm.py --describe "TM Element Boundary ExternalEntity Actor Lambda Server Process SetOfProcesses Datastore Dataflow"
+	poetry run python tm.py --describe "TM Element Boundary ExternalEntity Actor Lambda Server Process SetOfProcesses Datastore Dataflow"
 
 .PHONY: image
 image:
@@ -69,4 +63,4 @@ docs: docs/pytm/index.html docs/threats.md
 
 .PHONY: fmt
 fmt:
-	black  $(wildcard pytm/*.py) $(wildcard tests/*.py) $(wildcard *.py)
+	poetry run black  $(wildcard pytm/*.py) $(wildcard tests/*.py) $(wildcard *.py)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -e
+
+TARGET="${1:-all}"
+MODEL_FILE="${2:-tm.py}"
+MODEL=$(basename "${MODEL_FILE}" .py)
+WORK_DIR=/work
+OUTPUT_DIR="${WORK_DIR}/${MODEL}"
+
+if [ ! -f "${WORK_DIR}/${MODEL_FILE}" ]; then
+    echo "Error: ${MODEL_FILE} not found in mounted directory"
+    echo "Usage: docker run --rm -v \$(pwd):/work pytm [dfd|seq|report|all] [model.py]"
+    exit 1
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+
+run_dfd() {
+    echo "Generating DFD..."
+    python "${WORK_DIR}/${MODEL}.py" --dfd | dot -Tpng -o "${OUTPUT_DIR}/dfd.png"
+}
+
+run_seq() {
+    echo "Generating sequence diagram..."
+    python "${WORK_DIR}/${MODEL}.py" --seq \
+        | java -Djava.awt.headless=true -jar "${PLANTUML_PATH}" -tpng -pipe \
+        > "${OUTPUT_DIR}/seq.png"
+}
+
+run_report() {
+    echo "Generating report..."
+    python "${WORK_DIR}/${MODEL}.py" --report /app/docs/basic_template.md \
+        | pandoc -f markdown-tex_math_dollars -t html \
+        > "${OUTPUT_DIR}/report.html"
+}
+
+case "${TARGET}" in
+    dfd)    run_dfd ;;
+    seq)    run_seq ;;
+    report) run_report ;;
+    all)
+        run_dfd
+        run_seq
+        run_report
+        ;;
+    *)
+        echo "Unknown target: ${TARGET}"
+        echo "Usage: docker run --rm -v \$(pwd):/work pytm [dfd|seq|report|all] [model.py]"
+        exit 1
+        ;;
+esac
+
+echo "Output written to ${MODEL}/"


### PR DESCRIPTION
Changes:
- Fix broken URLs in Dockerfile
- Bump base image for Dockerfile
- Update to use poetry to manage dependencies
- Use poetry to run commands in Makefile so that the virtual environment is used
- Add entrypoint.sh to remove complexity/overloading in Makefile

The docker image can now be used like this:
```
docker run --rm -v $(pwd):/work pytm:latest dfd
```
or
```
docker run --rm -v $(pwd):/work pytm:latest dfd other_tm.py
```

This means the docker image can be used without the `Makefile` which makes it more portable

`make` can still be used as per normal, but it removes the complexity of trying to use docker as a shell (which didn't seem to work well)