### PR TITLE
Fix getInScopeFindings regression introduced by Pydantic refactor

### DIFF
--- a/pytm/report_util.py
+++ b/pytm/report_util.py
@@ -44,7 +44,7 @@ class ReportUtils:
 
         in_scope_findings = []
         for finding in element.findings:
-            target = getattr(finding, "target", None)
+            target = getattr(finding, "element", None)
             if target is not None and getattr(target, "inScope", False):
                 in_scope_findings.append(finding)
 

--- a/tests/test_report_util.py
+++ b/tests/test_report_util.py
@@ -83,3 +83,122 @@ def test_get_element_type_rejects_non_element():
     message = ReportUtils.getElementType(object())
 
     assert message == "ERROR: getElementType method is not valid for object"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_finding(element):
+    """Return a Finding attached to *element* using fixed test values."""
+    return Finding(
+        element=element,
+        id="F1",
+        threat_id="T1",
+        description="desc",
+        details="details",
+        severity="High",
+        mitigations="mit",
+        example="example",
+        references="refs",
+        condition="cond",
+    )
+
+
+# ---------------------------------------------------------------------------
+# getInScopeFindings — non-element input
+# ---------------------------------------------------------------------------
+
+def test_get_in_scope_findings_rejects_non_element():
+    assert ReportUtils.getInScopeFindings(object()) == []
+
+
+# ---------------------------------------------------------------------------
+# getInScopeFindings — out-of-scope element
+# ---------------------------------------------------------------------------
+
+def test_get_in_scope_findings_returns_empty_for_out_of_scope_element():
+    server = Server("OutOfScope")
+    server.inScope = False
+    server.findings.append(_make_finding(server))
+
+    result = ReportUtils.getInScopeFindings(server)
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# getInScopeFindings — in-scope element
+# ---------------------------------------------------------------------------
+
+def test_get_in_scope_findings_returns_findings_for_in_scope_element():
+    """An in-scope element with findings should have those findings returned."""
+    server = Server("InScope")
+    finding = _make_finding(server)
+    server.findings.append(finding)
+
+    result = ReportUtils.getInScopeFindings(server)
+
+    assert len(result) == 1
+    assert result[0] is finding
+
+
+def test_get_in_scope_findings_returns_all_findings_for_in_scope_element():
+    server = Server("InScope2")
+    f1 = _make_finding(server)
+    f2 = Finding(
+        element=server,
+        id="F2",
+        threat_id="T2",
+        description="desc2",
+        details="details2",
+        severity="Low",
+        mitigations="mit2",
+        example="ex2",
+        references="refs2",
+        condition="cond2",
+    )
+    server.findings.extend([f1, f2])
+
+    result = ReportUtils.getInScopeFindings(server)
+
+    assert len(result) == 2
+
+
+def test_get_in_scope_findings_returns_empty_when_no_findings():
+    server = Server("Clean")
+
+    result = ReportUtils.getInScopeFindings(server)
+
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# getInScopeFindings — no cross-element leakage (regression for issue #310)
+# ---------------------------------------------------------------------------
+
+def test_get_in_scope_findings_does_not_leak_findings_across_elements():
+    """Findings on one element must not appear on a different element."""
+    server_a = Server("ServerA")
+    server_b = Server("ServerB")
+
+    finding_a = _make_finding(server_a)
+    server_a.findings.append(finding_a)
+
+    # ServerB has no findings of its own
+    result = ReportUtils.getInScopeFindings(server_b)
+
+    assert result == []
+
+
+def test_get_in_scope_findings_out_of_scope_element_is_independent_of_previous_in_scope():
+    """Out-of-scope element must not inherit findings from a preceding in-scope element."""
+    in_scope = Server("InScopeServer")
+    out_of_scope = Server("OutOfScopeServer")
+    out_of_scope.inScope = False
+
+    in_scope.findings.append(_make_finding(in_scope))
+
+    result = ReportUtils.getInScopeFindings(out_of_scope)
+
+    assert result == []


### PR DESCRIPTION
Fixes: #310
Regression introduced by: #320 

What broke and why
                                                                                                                                       
PR #312 fixed issue #310 by adding `ReportUtils.getInScopeFindings()`, which filters threat findings to only those belonging to in-scope elements. The fix worked correctly against the pre-Pydantic codebase, where `Finding.target` held an `Element` object reference.
                                                                                                                                       
The Pydantic refactor (PR #320) changed `Finding.target` to a str (the element's name). This silently broke `getInScopeFindings`, the inner loop was now doing:
```                                                                                                                                 
  getattr("Web Server", "inScope", False)  # always False
```

The result: `getInScopeFindings` returned [] for every element, including in-scope ones. All threat findings were hidden from advanced_template.md and reveal.md reports.
                                                                                                                                       
The out-of-scope case appeared to still work (returning []) but only because of the early-return guard at the top of the function, not because the inner loop was correct.
                                                                                                                                       
The fix
One-line change in report_util.py: use finding.element (the Element reference, set by Finding.__init__) instead of finding.target (the name string).
                                              
Note on root cause                      
The original state-bleed described in #310 (findings from one element appearing on another) was caused by a shared class-level list in the old descriptor system. That root cause was independently fixed by the Pydantic refactor, which uses default_factory=list to give each element instance its own findings list. The fix in this PR restores the template-level filtering that was broken as a side effect.                                                                                                                              
                                         
Tests
                                 
Seven new tests added to tests/test_report_util.py, covering:                                          
  - Non-element input returns []
  - Out-of-scope element returns []
  - In-scope element with one finding returns it
  - In-scope element with multiple findings returns all of them
  - In-scope element with no findings returns []
  - Findings on one element do not appear on a different element (regression guard for #310)
  - Out-of-scope element is unaffected by findings on a preceding in-scope element
