### PR TITLE
Add LLM threat for untrusted tool launch configuration

### DIFF
--- a/pytm/__init__.py
+++ b/pytm/__init__.py
@@ -1,5 +1,6 @@
 __all__ = [
     "Action",
+    "Agent",
     "Actor",
     "Assumption",
     "Boundary",
@@ -38,7 +39,7 @@ from .element import Element
 from .data import Data
 from .threat import Threat
 from .finding import Finding
-from .asset import Asset, Lambda, LLM, Server, ExternalEntity
+from .asset import Agent, Asset, Lambda, LLM, Server, ExternalEntity
 from .datastore import Datastore
 from .actor import Actor
 from .process import Process, SetOfProcesses
@@ -51,6 +52,7 @@ Element.model_rebuild()
 Data.model_rebuild()
 Finding.model_rebuild()
 Asset.model_rebuild()
+Agent.model_rebuild()
 Lambda.model_rebuild()
 LLM.model_rebuild()
 Server.model_rebuild()

--- a/pytm/asset.py
+++ b/pytm/asset.py
@@ -312,6 +312,8 @@ class LLM(Asset):
         processesUntrustedInput (bool): Does this LLM process untrusted input?
         hasRAG (bool): Does this LLM use retrieval-augmented generation?
         hasFineTuning (bool): Has this LLM been fine-tuned?
+        usesExternalTools (bool): Does this LLM use external tools or servers?
+        validatesToolLaunchConfig (bool): Does this LLM validate tool/server launch configuration before execution?
     """
 
     isThirdParty: bool = Field(
@@ -346,6 +348,13 @@ class LLM(Asset):
     hasFineTuning: bool = Field(
         default=False, description="Has this LLM been fine-tuned?"
     )
+    usesExternalTools: bool = Field(
+        default=False, description="Does this LLM use external tools or servers?"
+    )
+    validatesToolLaunchConfig: bool = Field(
+        default=False,
+        description="Does this LLM validate tool/server launch configuration before execution?",
+    )
 
     def __init__(self, name: str = None, **data):
         """Initialize an LLM.
@@ -374,6 +383,8 @@ class LLM(Asset):
                 - processesUntrustedInput (bool): Does this LLM process untrusted input?
                 - hasRAG (bool): Does this LLM use retrieval-augmented generation?
                 - hasFineTuning (bool): Has this LLM been fine-tuned?
+                - usesExternalTools (bool): Does this LLM use external tools or servers?
+                - validatesToolLaunchConfig (bool): Does this LLM validate tool/server launch configuration before execution?
         """
         super().__init__(name, **data)
 

--- a/pytm/asset.py
+++ b/pytm/asset.py
@@ -287,6 +287,56 @@ class ExternalEntity(Asset):
         super().__init__(name, **data)
 
 
+class Agent(Asset):
+    """An agentic harness that can reason with an LLM and invoke tools.
+
+    Attributes:
+        port (int): Default TCP port for incoming data flows
+        protocol (str): Default network protocol for incoming data flows
+        data (DataSet): pytm.Data object(s) in incoming data flows
+        inputs (List[Dataflow]): Incoming Dataflows
+        outputs (List[Dataflow]): Outgoing Dataflows
+        onAWS (bool): Is this asset on AWS?
+        handlesResources (bool): Does this asset handle resources?
+        usesEnvironmentVariables (bool): Does this asset use environment variables?
+        OS (str): Operating system
+        usesExternalTools (bool): Does this agent use external tools or servers?
+        validatesToolLaunchConfig (bool): Does this agent validate tool/server launch configuration before execution?
+    """
+
+    usesExternalTools: bool = Field(
+        default=False, description="Does this agent use external tools or servers?"
+    )
+    validatesToolLaunchConfig: bool = Field(
+        default=False,
+        description="Does this agent validate tool/server launch configuration before execution?",
+    )
+
+    def __init__(self, name: str = None, **data):
+        """Initialize an Agent.
+
+        Args:
+            name (str): Name of the agent.
+            **data: Optional agent properties:
+                - port (int): Default TCP port for incoming data flows
+                - protocol (str): Default network protocol for incoming data flows
+                - data (DataSet): pytm.Data object(s) in incoming data flows
+                - inputs (List[Dataflow]): Incoming Dataflows
+                - outputs (List[Dataflow]): Outgoing Dataflows
+                - onAWS (bool): Is this asset on AWS?
+                - handlesResources (bool): Does this asset handle resources?
+                - usesEnvironmentVariables (bool): Does this asset use environment variables?
+                - OS (str): Operating system
+                - usesExternalTools (bool): Does this agent use external tools or servers?
+                - validatesToolLaunchConfig (bool): Does this agent validate tool/server launch configuration before execution?
+        """
+        super().__init__(name, **data)
+
+    def _shape(self) -> str:
+        """Get shape for DFD representation."""
+        return "hexagon"
+
+
 class LLM(Asset):
     """A Large Language Model element, either third-party or self-hosted.
 
@@ -312,8 +362,6 @@ class LLM(Asset):
         processesUntrustedInput (bool): Does this LLM process untrusted input?
         hasRAG (bool): Does this LLM use retrieval-augmented generation?
         hasFineTuning (bool): Has this LLM been fine-tuned?
-        usesExternalTools (bool): Does this LLM use external tools or servers?
-        validatesToolLaunchConfig (bool): Does this LLM validate tool/server launch configuration before execution?
     """
 
     isThirdParty: bool = Field(
@@ -348,13 +396,6 @@ class LLM(Asset):
     hasFineTuning: bool = Field(
         default=False, description="Has this LLM been fine-tuned?"
     )
-    usesExternalTools: bool = Field(
-        default=False, description="Does this LLM use external tools or servers?"
-    )
-    validatesToolLaunchConfig: bool = Field(
-        default=False,
-        description="Does this LLM validate tool/server launch configuration before execution?",
-    )
 
     def __init__(self, name: str = None, **data):
         """Initialize an LLM.
@@ -383,8 +424,6 @@ class LLM(Asset):
                 - processesUntrustedInput (bool): Does this LLM process untrusted input?
                 - hasRAG (bool): Does this LLM use retrieval-augmented generation?
                 - hasFineTuning (bool): Has this LLM been fine-tuned?
-                - usesExternalTools (bool): Does this LLM use external tools or servers?
-                - validatesToolLaunchConfig (bool): Does this LLM validate tool/server launch configuration before execution?
         """
         super().__init__(name, **data)
 

--- a/pytm/json.py
+++ b/pytm/json.py
@@ -3,7 +3,7 @@ import json
 from .tm import TM
 from .boundary import Boundary
 from .dataflow import Dataflow
-from .asset import Asset, Server, ExternalEntity, Lambda, LLM
+from .asset import Agent, Asset, Server, ExternalEntity, Lambda, LLM
 from .datastore import Datastore
 from .actor import Actor
 from .process import Process, SetOfProcesses
@@ -11,6 +11,7 @@ from .enums import Action
 
 _ELEMENT_CLASSES = {
     "Asset": Asset,
+    "Agent": Agent,
     "Actor": Actor,
     "Server": Server,
     "ExternalEntity": ExternalEntity,

--- a/pytm/pytm.py
+++ b/pytm/pytm.py
@@ -29,7 +29,7 @@ from .element import Element
 from .data import Data
 from .threat import Threat
 from .finding import Finding
-from .asset import Asset, Lambda, LLM, Server, ExternalEntity
+from .asset import Agent, Asset, Lambda, LLM, Server, ExternalEntity
 from .datastore import Datastore
 from .actor import Actor
 from .process import Process, SetOfProcesses
@@ -136,6 +136,7 @@ def _list_elements():
 
 _CLASS_REGISTRY = {
     "Action": Action,
+    "Agent": Agent,
     "Actor": Actor,
     "Asset": Asset,
     "Boundary": Boundary,

--- a/pytm/threat.py
+++ b/pytm/threat.py
@@ -270,6 +270,7 @@ class Threat(BaseModel):
 
             globals_dict: dict[str, Any] = {
                 "__builtins__": cls._SAFE_BUILTINS,
+                "Agent": pytm.Agent,
                 "Actor": pytm.Actor,
                 "Asset": pytm.Asset,
                 "Boundary": pytm.Boundary,

--- a/pytm/threatlib/threats.json
+++ b/pytm/threatlib/threats.json
@@ -1727,14 +1727,14 @@
   {
     "SID": "LLM09",
     "target": [
-      "LLM"
+      "Agent"
     ],
     "description": "Untrusted Tool Launch Configuration",
-    "details": "An LLM agent that launches external tools or local servers from untrusted or weakly validated configuration can treat setup metadata as execution authority. In local tool integrations, including MCP-style stdio servers, command and argument configuration may determine which local process is started.",
+    "details": "An agentic harness that launches external tools or local servers from untrusted or weakly validated configuration can treat setup metadata as execution authority. In local tool integrations, including MCP-style stdio servers, command and argument configuration may determine which local process is started.",
     "Likelihood Of Attack": "High",
     "severity": "High",
-    "condition": "target.hasAgentCapabilities is True and target.usesExternalTools is True and target.validatesToolLaunchConfig is False",
-    "prerequisites": "The LLM has agent capabilities and can use external tools or local servers. Tool/server launch configuration is accepted without validation or policy checks.",
+    "condition": "target.usesExternalTools is True and target.validatesToolLaunchConfig is False",
+    "prerequisites": "The agentic harness can use external tools or local servers. Tool/server launch configuration is accepted without validation or policy checks.",
     "mitigations": "Validate tool and server launch configuration before execution. Use allowlisted commands and arguments, deny inline execution patterns, require explicit approval for new tools, and run tools with least privilege.",
     "example": "An agentic client loads a tool configuration that appears to be setup data but controls a local stdio server launch command. Without a policy gate, changing the configuration changes what local process is executed.",
     "references": "https://owasp.org/www-project-mcp-top-10/, https://owasp.org/www-project-top-10-for-large-language-model-applications/, https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/"

--- a/pytm/threatlib/threats.json
+++ b/pytm/threatlib/threats.json
@@ -1723,5 +1723,20 @@
     "mitigations": "Implement output filtering to detect and redact sensitive data patterns (PII, credentials, etc.). Use output encoding appropriate to the consumption context. Apply data loss prevention (DLP) controls on LLM outputs. Minimize the amount of sensitive data in the LLM's context.",
     "example": "A customer service LLM that has access to customer records is asked 'What is the account information for user X?' and returns their full name, address, and account number because no output filtering is in place to redact PII.",
     "references": "https://owasp.org/www-project-top-10-for-large-language-model-applications/, https://genai.owasp.org/llmrisk/llm06-sensitive-information-disclosure/"
+  },
+  {
+    "SID": "LLM09",
+    "target": [
+      "LLM"
+    ],
+    "description": "Untrusted Tool Launch Configuration",
+    "details": "An LLM agent that launches external tools or local servers from untrusted or weakly validated configuration can treat setup metadata as execution authority. In local tool integrations, including MCP-style stdio servers, command and argument configuration may determine which local process is started.",
+    "Likelihood Of Attack": "High",
+    "severity": "High",
+    "condition": "target.hasAgentCapabilities is True and target.usesExternalTools is True and target.validatesToolLaunchConfig is False",
+    "prerequisites": "The LLM has agent capabilities and can use external tools or local servers. Tool/server launch configuration is accepted without validation or policy checks.",
+    "mitigations": "Validate tool and server launch configuration before execution. Use allowlisted commands and arguments, deny inline execution patterns, require explicit approval for new tools, and run tools with least privilege.",
+    "example": "An agentic client loads a tool configuration that appears to be setup data but controls a local stdio server launch command. Without a policy gate, changing the configuration changes what local process is executed.",
+    "references": "https://owasp.org/www-project-mcp-top-10/, https://owasp.org/www-project-top-10-for-large-language-model-applications/, https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/"
   }
 ]

--- a/tests/test_pytmfunc.py
+++ b/tests/test_pytmfunc.py
@@ -1663,6 +1663,22 @@ class Testpytm:
         threat = threats["LLM08"]
         assert threat.apply(llm)
 
+    def test_LLM09(self):
+        llm = LLM("Tool Agent")
+        llm.hasAgentCapabilities = True
+        llm.usesExternalTools = True
+        llm.validatesToolLaunchConfig = False
+        threat = threats["LLM09"]
+        assert threat.apply(llm)
+
+    def test_LLM09_mitigated(self):
+        llm = LLM("Tool Agent")
+        llm.hasAgentCapabilities = True
+        llm.usesExternalTools = True
+        llm.validatesToolLaunchConfig = True
+        threat = threats["LLM09"]
+        assert not threat.apply(llm)
+
 
 class TestLLM:
     def test_defaults(self):
@@ -1681,6 +1697,8 @@ class TestLLM:
         assert llm.processesUntrustedInput is True
         assert llm.hasRAG is False
         assert llm.hasFineTuning is False
+        assert llm.usesExternalTools is False
+        assert llm.validatesToolLaunchConfig is False
 
     def test_shape(self):
         TM.reset()

--- a/tests/test_pytmfunc.py
+++ b/tests/test_pytmfunc.py
@@ -9,6 +9,7 @@ from pytm import (
     pytm,
     TM,
     Action,
+    Agent,
     Actor,
     Assumption,
     Boundary,
@@ -429,6 +430,7 @@ class TestTM:
     @pytest.mark.parametrize(
         "class_name,expected_type",
         [
+            ("Agent", Agent),
             ("Actor", Actor),
             ("Server", Server),
             ("Datastore", Datastore),
@@ -1664,20 +1666,18 @@ class Testpytm:
         assert threat.apply(llm)
 
     def test_LLM09(self):
-        llm = LLM("Tool Agent")
-        llm.hasAgentCapabilities = True
-        llm.usesExternalTools = True
-        llm.validatesToolLaunchConfig = False
+        agent = Agent("Tool Agent")
+        agent.usesExternalTools = True
+        agent.validatesToolLaunchConfig = False
         threat = threats["LLM09"]
-        assert threat.apply(llm)
+        assert threat.apply(agent)
 
     def test_LLM09_mitigated(self):
-        llm = LLM("Tool Agent")
-        llm.hasAgentCapabilities = True
-        llm.usesExternalTools = True
-        llm.validatesToolLaunchConfig = True
+        agent = Agent("Tool Agent")
+        agent.usesExternalTools = True
+        agent.validatesToolLaunchConfig = True
         threat = threats["LLM09"]
-        assert not threat.apply(llm)
+        assert not threat.apply(agent)
 
 
 class TestLLM:
@@ -1697,8 +1697,6 @@ class TestLLM:
         assert llm.processesUntrustedInput is True
         assert llm.hasRAG is False
         assert llm.hasFineTuning is False
-        assert llm.usesExternalTools is False
-        assert llm.validatesToolLaunchConfig is False
 
     def test_shape(self):
         TM.reset()
@@ -1712,6 +1710,28 @@ class TestLLM:
         llm = LLM("Test LLM")
         assert llm in TM._assets
         assert llm in TM._elements
+
+
+class TestAgent:
+    def test_defaults(self):
+        TM.reset()
+        TM("test tm")
+        agent = Agent("Test Agent")
+        assert agent.usesExternalTools is False
+        assert agent.validatesToolLaunchConfig is False
+
+    def test_shape(self):
+        TM.reset()
+        TM("test tm")
+        agent = Agent("Test Agent")
+        assert agent._shape() == "hexagon"
+
+    def test_registered_in_assets_and_elements(self):
+        TM.reset()
+        TM("test tm")
+        agent = Agent("Test Agent")
+        assert agent in TM._assets
+        assert agent in TM._elements
 
 
 class TestFinding:


### PR DESCRIPTION
## Summary

This adds a new LLM threat rule for AI agents that can start external tools or local helper servers.

The risk is that a tool configuration file can look like normal setup data, but still decide what program gets launched on the local machine. If an agentic system accepts that launch configuration without checking it first, changing the config can change what code runs.

This is especially relevant to local tool integrations such as MCP-style stdio servers, where command and argument fields may control the local process that is started.

## Changes

- Adds two LLM model fields:
  - `usesExternalTools`
  - `validatesToolLaunchConfig`
- Adds `LLM09: Untrusted Tool Launch Configuration`
- Adds tests for both vulnerable and mitigated configurations

## Testing

Passed locally:

- `$env:PYTHONUTF8='1'; python -m pytest tests\test_pytmfunc.py -k LLM`
- `$env:PYTHONUTF8='1'; python -m pytest tests\test_pydantic_models.py`
- `python -m json.tool pytm\threatlib\threats.json`

Note: Full `python -m pytest` on Windows, due to existing DFD fixture path separator mismatches and a temp directory permission error unrelated to this change.
