### PR TITLE
Modernize python package setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
-        run: pip install poetry
+        run: pip install "poetry>=2.1"
       - name: Update poetry.lock
         run: poetry lock 
       - name: Install dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,38 @@ To execute the test suite, from the root of the repo run `make test`. To control
 
 To regenerate test fixtures for `json.dumps` and report tests add a `print(output)` statement in the test and run `make test 2>/dev/null > tests/output.json` or  `make test 2>/dev/null > tests/output.md`.
 
+## Development
+
+### Environment
+
+`pyproject.toml` describes the project with standard `[project]` metadata, so any PEP 517 tool
+can install pytm together with its development dependencies:
+
+    uv sync --dev
+    pip install -e . --group dev    # pip 25.1 or newer
+
+Note that the `Makefile` targets drive the tools through Poetry, so reach for `pytest` and the
+`pytm` modules directly in an environment installed this way.
+
+### Dependencies
+
+Dependency changes go into `pyproject.toml` - runtime ones under `[project.dependencies]`,
+tooling under the `dev` group of `[dependency-groups]`. The repo also carries a `poetry.lock`
+that the CI workflow regenerates on each run, so refresh it in your PR when you change
+dependencies to keep the two in step.
+
+### Building
+
+The build backend is [hatchling](https://hatch.pypa.io/latest/), driven entirely by the
+`[project]` table, so every frontend produces the same artifacts:
+
+    uv build
+    python -m build
+
+### Bumping the version
+
+The version lives in `[project].version` - edit it there.
+
 ## PyTM-users
 
 Before you post to the [PyTM-users list](https://groups.google.com/forum/#!forum/pytm-users), make sure you look for existing solutions.

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,6 @@ COPY pytm ./pytm
 COPY docs ./docs
 COPY *.py Makefile entrypoint.sh ./
 
-RUN pip install poetry \
+RUN pip install "poetry>=2.1" \
     && poetry config virtualenvs.create false \
     && poetry install

--- a/poetry.lock
+++ b/poetry.lock
@@ -633,5 +633,5 @@ typing-extensions = ">=4.12.0"
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.11"
-content-hash = "a92fc2ee52f70f5920846fb92e9afb0b1acce7a4e8e40f2e69294320f0ab54e7"
+python-versions = ">=3.11,<3.15"
+content-hash = "a6000fab042dfc46fb1a867721f79a67db5334727f360db23953adab04c8d5ac"

--- a/poetry.lock
+++ b/poetry.lock
@@ -634,4 +634,4 @@ typing-extensions = ">=4.12.0"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.15"
-content-hash = "a6000fab042dfc46fb1a867721f79a67db5334727f360db23953adab04c8d5ac"
+content-hash = "f4238c8a1f5b27910133f8160430adf18273c52749fbd59c9250c3909fb35111"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,18 +22,20 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/OWASP/pytm"
 
+[dependency-groups]
+dev = [
+    "pytest>=8.3.5,<10.0.0",
+    "black>=25.9,<27.0",
+    "pdoc3>=0.11.6,<0.12.0",
+    "ruff>=0.15.11,<0.16.0",
+]
+
 [tool.poetry]
 packages = [{include = "pytm"}]
 include = [
     "pytm/images/*.png",
     "pytm/threatlib/threats.json",
 ]
-
-[tool.poetry.group.dev.dependencies]
-pytest = ">=8.3.5,<10.0.0"
-black = ">=25.9,<27.0"
-pdoc3 = "^0.11.6"
-ruff = "^0.15.11"
 
 [tool.ruff]
 target-version = "py311"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,13 @@
-[tool.poetry]
+[project]
 name = "pytm"
 version = "1.4.0"
 description = "A Pythonic framework for threat modeling"
-authors = ["pytm Team <please_use_github_issues@nowhere.com>"]
-license = "MIT License"
+authors = [{ name = "pytm Team", email = "please_use_github_issues@nowhere.com" }]
+license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/OWASP/pytm"
-packages = [{include = "pytm"}]
-include = [
-    "pytm/images/*.png",
-    "pytm/threatlib/threats.json",
-]
+requires-python = ">=3.11,<3.15"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
@@ -21,10 +15,19 @@ classifiers = [
     "Topic :: Security",
     "Natural Language :: English",
 ]
+dependencies = [
+    "pydantic>=2.10.0,<3.0.0",
+]
 
-[tool.poetry.dependencies]
-python = "^3.11"
-pydantic = "^2.10.0"
+[project.urls]
+Homepage = "https://github.com/OWASP/pytm"
+
+[tool.poetry]
+packages = [{include = "pytm"}]
+include = [
+    "pytm/images/*.png",
+    "pytm/threatlib/threats.json",
+]
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.3.5,<10.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,6 @@ dev = [
     "ruff>=0.15.11,<0.16.0",
 ]
 
-[tool.poetry]
-packages = [{include = "pytm"}]
-include = [
-    "pytm/images/*.png",
-    "pytm/threatlib/threats.json",
-]
-
 [tool.ruff]
 target-version = "py311"
 
@@ -54,5 +47,8 @@ ignore = [
 ]
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["pytm"]


### PR DESCRIPTION
While starting with pytm, I saw a few things regarding package management that could use improvement, especially as the Python folks use pure pip or uv currently, and maybe wondering why the commands don't work.

This PR includes migration to the default pyproject.toml keys which poetry in version 2 also understands, so nothing breaks.  As pip can handle these as well, we can remove a few other files which existed for compatibility reasons (?) as well.

