### PR TITLE
Fix out-of-scope elements inheriting other elements' findings in resolve()

### DIFF
--- a/pytm/tm.py
+++ b/pytm/tm.py
@@ -319,7 +319,7 @@ a brief description of the system being modeled."""
 
         for e in TM._elements:
             if not getattr(e, "inScope", True):
-                e.findings = findings
+                e.findings = []
                 continue
 
             override_ids = set(f.threat_id for f in getattr(e, "overrides", []))

--- a/tests/test_pytmfunc.py
+++ b/tests/test_pytmfunc.py
@@ -242,16 +242,23 @@ class TestTM:
         assert excluded_threat not in [t.threat_id for t in tm.findings]
         assert remaining_threat in [t.threat_id for t in tm.findings]
 
-    def test_resolve(self):
+    @pytest.mark.parametrize("out_of_scope_first", [True, False])
+    def test_resolve(self, out_of_scope_first):
         random.seed(0)
 
         TM.reset()
         tm = TM("my test tm", description="aaa")
         internet = Boundary("Internet")
         server_db = Boundary("Server/DB")
-        user = Actor("User", inBoundary=internet, inScope=False)
+        # resolve() visits elements in creation order, so cover the
+        # out-of-scope element both before any findings exist and after
+        # findings for the in-scope elements have accumulated.
+        if out_of_scope_first:
+            user = Actor("User", inBoundary=internet, inScope=False)
         web = Server("Web Server")
         db = Datastore("SQL Database", inBoundary=server_db)
+        if not out_of_scope_first:
+            user = Actor("User", inBoundary=internet, inScope=False)
 
         req = Dataflow(user, web, "User enters comments (*)")
         query = Dataflow(web, db, "Insert query with comments")


### PR DESCRIPTION
`TM.resolve()` was assigning the in-progress findings list to out-of-scope elements instead of skipping them:

```
  if not getattr(e, "inScope", True):
      e.findings = findings
      continue
```

Since findings accumulates as the element loop runs, any element with inScope=False ended up with a copy of every finding generated for elements processed before it. Reports then showed findings against the exact elements that were declared out of scope, targeting completely different parts of the model.

The existing `test_resolve` didn't catch this because its out-of-scope actor happened to be created before any finding-producing elements, so the leaked list was still empty at that point. Element creation order determines iteration order in `resolve()`, so the bug only shows up when an out-of-scope element is defined after in-scope ones.

Changes:
- `resolve()` now sets findings to an empty list for out-of-scope elements. This also clears stale findings if a model is resolved again after flipping an element out of scope.
- Parametrised `test_resolve` to cover both creation orders (out-of-scope element defined first and last), so the leaking variant stays covered.