### PR TITLE
Fix finding overrides wiping values copied from the threat

### DIFF
--- a/pytm/finding.py
+++ b/pytm/finding.py
@@ -119,9 +119,13 @@ class Finding(BaseModel):
         if hasattr(element, "overrides") and threat_id:
             for override in element.overrides:
                 if getattr(override, "threat_id", None) == threat_id:
-                    # Apply override values
+                    # Apply only fields explicitly set on the override, so
+                    # values copied from the threat (and the finding id) are
+                    # not clobbered by the override's backfilled defaults.
                     override_dict = (
-                        override.model_dump() if hasattr(override, "model_dump") else {}
+                        override.model_dump(exclude_unset=True)
+                        if hasattr(override, "model_dump")
+                        else {}
                     )
                     for key, value in override_dict.items():
                         if key not in ("element", "target") and value is not None:
@@ -140,11 +144,14 @@ class Finding(BaseModel):
             "references",
             "condition",
         ]
-        for field in required_fields:
-            if field not in kwargs:
-                kwargs[field] = ""
+        backfilled = [field for field in required_fields if field not in kwargs]
+        for field in backfilled:
+            kwargs[field] = ""
 
         super().__init__(**kwargs)
+        # Backfilled placeholders are not caller-provided values; drop them
+        # from the fields-set so model_dump(exclude_unset=True) ignores them.
+        self.__pydantic_fields_set__.difference_update(backfilled)
 
     def _safeset(self, attr: str, value) -> None:
         """Safely set an attribute value."""

--- a/tests/test_pytmfunc.py
+++ b/tests/test_pytmfunc.py
@@ -352,8 +352,21 @@ class TestTM:
         )
 
         TM._threats = [
-            Threat(SID="Server", severity="High", target="Server", condition="False"),
-            Threat(SID="Datastore", target="Datastore", severity="High"),
+            Threat(
+                SID="Server",
+                severity="High",
+                description="Server can be attacked",
+                mitigations="Use TLS",
+                target="Server",
+                condition="False",
+            ),
+            Threat(
+                SID="Datastore",
+                target="Datastore",
+                severity="High",
+                description="Datastore can be attacked",
+                mitigations="Encrypt at rest",
+            ),
         ]
         tm.resolve()
 
@@ -364,6 +377,16 @@ class TestTM:
             "accepted since inside the trust boundary"
         ]
         assert [f.cvss for f in db.findings] == ["9.876"]
+
+        # Fields the override does not set must keep the values copied from
+        # the matched threat, and the finding id assigned by resolve().
+        assert [f.id for f in tm.findings] == ["1", "2"]
+        assert [f.severity for f in web.findings] == ["High"]
+        assert [f.description for f in web.findings] == ["Server can be attacked"]
+        assert [f.mitigations for f in web.findings] == ["Use TLS"]
+        assert [f.severity for f in db.findings] == ["High"]
+        assert [f.description for f in db.findings] == ["Datastore can be attacked"]
+        assert [f.mitigations for f in db.findings] == ["Encrypt at rest"]
 
     def test_json_dumps(self):
         random.seed(0)


### PR DESCRIPTION
When a finding matched an element override, `Finding.__init__` merged in the full `model_dump()` of the override. Since overrides backfill required fields with empty strings, an override that only set response or cvss would blank out the finding's description, severity, mitigations — and the finding id assigned by `resolve()`.
  
The merge now uses `model_dump(exclude_unset=True)`, and the constructor no longer records its backfilled placeholders in `__pydantic_fields_set__`, so only fields actually set on the override are applied.
  
Extended `test_overrides` to assert that threat-sourced fields and the finding id survive an override — it only checked the overridden fields before, which is how this slipped through.