### PR TITLE
Fix JSON round-trip: loads() couldn't read dumps() output

### DIFF
--- a/pytm/enums.py
+++ b/pytm/enums.py
@@ -3,7 +3,26 @@
 from enum import Enum
 
 
-class Action(Enum):
+class FlexibleEnumMixin:
+    """Also accept member names and their str() form ("ClassName.MEMBER").
+
+    Serialized threat models store enums as str(member), so this lets
+    Classification("Classification.SECRET") and Classification("SECRET")
+    resolve alongside the regular by-value lookup.
+    """
+
+    @classmethod
+    def _missing_(cls, value):
+        if not isinstance(value, str):
+            return None
+        name = value.removeprefix(f"{cls.__name__}.")
+        try:
+            return cls[name]
+        except KeyError:
+            return None
+
+
+class Action(FlexibleEnumMixin, Enum):
     """Action taken when validating a threat model."""
 
     NO_ACTION = "NO_ACTION"
@@ -11,7 +30,7 @@ class Action(Enum):
     IGNORE = "IGNORE"
 
 
-class OrderedEnum(Enum):
+class OrderedEnum(FlexibleEnumMixin, Enum):
     """Base enum class that supports ordering operations."""
 
     def __ge__(self, other):
@@ -46,7 +65,7 @@ class Classification(OrderedEnum):
     TOP_SECRET = 5
 
 
-class Lifetime(Enum):
+class Lifetime(FlexibleEnumMixin, Enum):
     """Credential lifetime categories."""
 
     # not applicable
@@ -68,7 +87,7 @@ class Lifetime(Enum):
         return self.value.lower().replace("_", " ")
 
 
-class DatastoreType(Enum):
+class DatastoreType(FlexibleEnumMixin, Enum):
     """Types of datastores."""
 
     UNKNOWN = "UNKNOWN"

--- a/pytm/json.py
+++ b/pytm/json.py
@@ -37,10 +37,16 @@ def load(fp):
     return _decode(result)
 
 
+# Attributes that hold state derived from flows during check()/resolve(),
+# or that are serialized in a lossy form (names/ids only). They cannot be
+# restored directly, so they are dropped and rebuilt when the model is run.
+_DERIVED_ATTRS = ("findings", "inputs", "outputs", "overrides")
+
+
 def _decode(flat):
     boundaries = _decode_boundaries(flat.pop("boundaries", []))
     data = _decode_data(flat.pop("data", []))
-    elements = _decode_elements(flat.pop("elements", []), boundaries)
+    elements = _decode_elements(flat.pop("elements", []), boundaries, data)
     _decode_flows(flat.pop("flows", []), elements, data)
 
     if "name" not in flat:
@@ -57,8 +63,11 @@ def _decode_boundaries(flat):
         name = e.pop("name", None)
         if name is None:
             raise ValueError(f"name property missing in boundary {i}")
-        if "inBoundary" in e:
-            refs[name] = e.pop("inBoundary")
+        ref = e.pop("inBoundary", None)
+        if ref is not None:
+            refs[name] = ref
+        for attr in _DERIVED_ATTRS:
+            e.pop(attr, None)
         e = Boundary(name, **e)
         boundaries[name] = e
 
@@ -78,13 +87,16 @@ def _decode_data(flat):
         if name is None:
             raise ValueError(f"name property missing in data {i}")
 
+        for attr in ("carriedBy", "processedBy"):
+            e.pop(attr, None)
+
         classification_name = e.pop("classification", None)
         if classification_name:
-            e["classification"] = Classification[classification_name]
+            e["classification"] = Classification(classification_name)
 
         lifetime_name = e.pop("lifetime", None)
         if lifetime_name:
-            e["lifetime"] = Lifetime[lifetime_name]
+            e["lifetime"] = Lifetime(lifetime_name)
 
         d = Data(name, **e)
         data[name] = d
@@ -92,7 +104,7 @@ def _decode_data(flat):
     return data
 
 
-def _decode_elements(flat, boundaries):
+def _decode_elements(flat, boundaries, data):
     elements = {}
     for i, e in enumerate(flat):
         class_name = e.pop("__class__", "Asset")
@@ -102,19 +114,38 @@ def _decode_elements(flat, boundaries):
         name = e.pop("name", None)
         if name is None:
             raise ValueError(f"name property missing in element {i}")
-        if "inBoundary" in e:
-            if e["inBoundary"] not in boundaries:
+        boundary_ref = e.pop("inBoundary", None)
+        if boundary_ref is not None:
+            if boundary_ref not in boundaries:
                 raise ValueError(
-                    f"element {name} references invalid boundary {e['inBoundary']}"
+                    f"element {name} references invalid boundary {boundary_ref}"
                 )
-            e["inBoundary"] = boundaries[e["inBoundary"]]
+            e["inBoundary"] = boundaries[boundary_ref]
+        for attr in _DERIVED_ATTRS:
+            e.pop(attr, None)
+        if "data" in e:
+            e["data"] = _resolve_data_refs(e["data"], data, f"element {name}")
         e = klass(name, **e)
         elements[name] = e
 
     return elements
 
 
+def _resolve_data_refs(refs, data, context):
+    dataset = DataSet()
+    for ref in refs:
+        if not isinstance(ref, str):
+            dataset.add(ref)
+            continue
+        if ref not in data:
+            raise ValueError(f"{context} references invalid data {ref}")
+        dataset.add(data[ref])
+    return dataset
+
+
 def _decode_flows(flat, elements, data):
+    flows = {}
+    response_refs = {}
     for i, e in enumerate(flat):
         name = e.pop("name", None)
         if name is None:
@@ -130,12 +161,24 @@ def _decode_flows(flat, elements, data):
             raise ValueError(f"dataflow {name} references invalid sink {e['sink']}")
         sink = elements[e.pop("sink")]
 
-        if "data" in e:
-            dataset = DataSet()
-            for data_name in e["data"]:
-                if data_name not in data:
-                    raise ValueError(f"dataflow {name} references invalid data {data_name}")
-                dataset.add(data[data_name])
-            e["data"] = dataset
+        for attr in _DERIVED_ATTRS:
+            e.pop(attr, None)
 
-        Dataflow(source, sink, name, **e)
+        # Responses reference other flows by name; link them in a second
+        # pass once all flows exist.
+        refs = (e.pop("response", None), e.pop("responseTo", None))
+        if any(ref is not None for ref in refs):
+            response_refs[name] = refs
+
+        if "data" in e:
+            e["data"] = _resolve_data_refs(e["data"], data, f"dataflow {name}")
+
+        flows[name] = Dataflow(source, sink, name, **e)
+
+    for name, (response_ref, response_to_ref) in response_refs.items():
+        for attr, ref in (("response", response_ref), ("responseTo", response_to_ref)):
+            if ref is None:
+                continue
+            if ref not in flows:
+                raise ValueError(f"dataflow {name} references invalid dataflow {ref}")
+            setattr(flows[name], attr, flows[ref])

--- a/tests/test_pytmfunc.py
+++ b/tests/test_pytmfunc.py
@@ -435,6 +435,65 @@ class TestTM:
             },
         ]
 
+    def test_json_round_trip(self):
+        random.seed(0)
+
+        TM.reset()
+        tm = TM(
+            "my test tm",
+            description="aaa",
+            isOrdered=True,
+            onDuplicates=Action.IGNORE,
+            threatsFile="pytm/threatlib/threats.json",
+        )
+        internet = Boundary("Internet")
+        server_db = Boundary("Server/DB")
+        user = Actor("User", inBoundary=internet)
+        web = Server("Web Server")
+        db = Datastore("SQL Database", inBoundary=server_db)
+
+        password = Data(
+            "Password",
+            classification=Classification.SECRET,
+            isCredentials=True,
+            credentialsLife=Lifetime.LONG,
+        )
+        req = Dataflow(user, web, "Request")
+        Dataflow(web, db, "Insert", data=[password])
+        Dataflow(web, user, "Response", responseTo=req)
+
+        assert tm.check()
+        output = json.dumps(tm, default=to_serializable)
+
+        TM.reset()
+        tm2 = loads(output)
+
+        assert tm2.name == "my test tm"
+        assert tm2.description == "aaa"
+        assert tm2.isOrdered is True
+        assert tm2.onDuplicates == Action.IGNORE
+
+        assert [b.name for b in tm2._boundaries] == ["Internet", "Server/DB"]
+
+        elements = {e.name: e for e in tm2._elements}
+        assert isinstance(elements["Web Server"], Server)
+        assert isinstance(elements["SQL Database"], Datastore)
+        assert elements["User"].inBoundary is elements["Internet"]
+        assert elements["SQL Database"].inBoundary is elements["Server/DB"]
+
+        data = {d.name: d for d in tm2._data}
+        assert data["Password"].classification == Classification.SECRET
+        assert data["Password"].credentialsLife == Lifetime.LONG
+        assert data["Password"].isCredentials is True
+
+        flows = {f.name: f for f in tm2._flows}
+        assert sorted(flows) == ["Insert", "Request", "Response"]
+        assert "Password" in flows["Insert"].data
+        assert flows["Response"].isResponse
+        assert flows["Response"].responseTo is flows["Request"]
+
+        assert tm2.check()
+
     @pytest.mark.parametrize(
         "class_name,expected_type",
         [


### PR DESCRIPTION
The JSON produced by `--json` couldn't be loaded back with `pytm.loads()`. The dump writes enums as `str(member)` `("Classification.SECRET")` while the loader expected bare member names, it writes "inBoundary": null which the loader treated as a real reference, and it serializes derived state (findings, inputs/outputs, carriedBy) as name strings that blow up when passed into typed fields.

Changes:
- Added a `_missing_` hook to the pytm enums so both "SECRET" and "Classification.SECRET" resolve. This covers every enum field in one place, including Pydantic validation on elements. The dump format itself is unchanged.
- The loader now skips derived attributes — they're rebuilt by `check()`/`resolve()` anyway — and ignores null boundary refs.
- Flow response/responseTo references are linked in a second pass once all flows exist, so request/response pairs survive a reload.
- Asset data name references now resolve against the decoded data section, same as flows.

Added `test_json_round_trip`, which dumps a model with nested boundaries, classified data and a response flow, reloads it, and checks the relationships survive. Existing hand-written JSON fixtures still load as before.